### PR TITLE
[Feat] 플레이어 데이터 관리 및 등록, 조회 관리

### DIFF
--- a/Assets/LTH/LTH_Scripts/Players.meta
+++ b/Assets/LTH/LTH_Scripts/Players.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ff10c95acde096841a81cbd590faab4b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LTH/LTH_Scripts/Players/GamePlayer.cs
+++ b/Assets/LTH/LTH_Scripts/Players/GamePlayer.cs
@@ -1,0 +1,47 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// 각 플레이어의 게임 내 상태(UID, 닉네임, 턴, 위치, 승리 여부 등)를 저장하고 관리
+/// --------------------------------------------------------------------------------
+/// 각 플레이어의 고유 식별 정보(Firebase UID, 닉네임) 보관
+/// 게임 세션 중의 상태 관리 (턴 여부, 준비 여부, 보드 위치 등)
+/// 미니게임 및 메인맵 결과 저장 (승리 여부, 승수 등)
+/// 게임 흐름 제어 로직에서 기준 정보로 활용됨
+/// </summary>
+
+
+public class GamePlayer : MonoBehaviour
+{
+    #region 플레이어의 고유 정보
+    public string PlayerId { get; private set; }    // Firebase UID
+    public string Nickname { get; private set; }    // 플레이어 닉네임 (Photon)
+    #endregion
+
+    #region 플레이어 상태 정보
+    public bool IsReady { get; private set; }       // 현재 플레이어 게임 입장 준비 상태
+    public bool IsTurn { get; private set; }        // 현재 플레이어의 턴 여부
+    #endregion
+
+    public bool WinThisMiniGame { get; set; }       // 미니게임에서 승리 여부
+
+    public int BoardPosition { get; set; }          // 현재 보드에서의 위치 (0부터 시작, 0은 시작점)
+
+
+    // 전체 게임에서 이긴 횟수 (이건 순위 정렬이나 추후에 랭크에 사용하는 경우 사용)
+    public int WinCount { get; set; }
+
+    public GamePlayer(string id, string nickname)
+    {
+        PlayerId = id;
+        Nickname = nickname;
+
+        IsReady = false;
+        IsTurn = false;
+
+        WinCount = 0;
+        BoardPosition = 0;
+        WinThisMiniGame = false;
+    }
+}

--- a/Assets/LTH/LTH_Scripts/Players/GamePlayer.cs.meta
+++ b/Assets/LTH/LTH_Scripts/Players/GamePlayer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8657508b3d590e643832ac310db090ff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LTH/LTH_Scripts/Players/PlayerManager.cs
+++ b/Assets/LTH/LTH_Scripts/Players/PlayerManager.cs
@@ -1,0 +1,46 @@
+using System.Collections;
+using System.Collections.Generic;
+using DesignPattern;
+using Photon.Pun;
+using UnityEngine;
+
+/// <summary>
+/// Firebase UID 기준으로 각 플레이어의 GamePlayer 인스턴스를 등록/조회하는 전역 관리 싱글톤
+/// </summary>
+
+public class PlayerManager : CombinedSingleton<PlayerManager>
+{
+    // Key: string 형태의 Firebase UID
+    // Value: GamePlayer 인스턴스
+    private Dictionary<string, GamePlayer> players = new();
+
+    public IReadOnlyDictionary<string, GamePlayer> Players => players;
+
+
+    /// <summary>
+    /// 플레이어 등록 메서드
+    /// id는 UID, nickname은 표시용 Photon 닉네임
+    /// </summary>
+    public void RegisterPlayer(string id, string nickname)
+    {
+        if (!players.ContainsKey(id)) // 중복 등록 방지
+        {
+            players.Add(id, new GamePlayer(id, nickname));
+        }
+    }
+
+    /// <summary>
+    /// 특정 플레이어의 데이터를 UID 기준으로 가져옴
+    /// </summary>
+    public GamePlayer GetPlayer(string id)
+    {
+        players.TryGetValue(id, out var player);
+        return player;
+    }
+
+    /// <summary>
+    /// Firebase UID를 기준으로 현재 클라이언트의 GamePlayer 데이터를 조회
+    /// FirebaseAuthManager는 예시이며, 다른 클래스이면 수정하여 작업하시면 됩니다.
+    /// <summary>
+    // public GamePlayer LocalPlayer => GetPlayer(FirebaseAuthManager.UserUID);
+}

--- a/Assets/LTH/LTH_Scripts/Players/PlayerManager.cs.meta
+++ b/Assets/LTH/LTH_Scripts/Players/PlayerManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f6e874115acc1f4f85c6b0d25803f37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
1. 각 플레이어의 게임 내 상태(UID, 닉네임, 턴, 위치, 승리 여부 등)를 저장하는 클래스 생성 (GamePlayer)

2. Firebase UID 기준으로 각 플레이어의 GamePlayer 인스턴스를 등록/조회하는 전역 관리 싱글톤 (PlayerManager)

# 🧑‍💻 PR

## 🔥 작업 내용 요약
1. Feat - 플레이어 데이터 저장 클래스
2. Feat - 플레이어 전역 클래스 (Firebase UID 기준으로 각 플레이어)
<br>

## 💻 작업 구현 방법 (공통)
### 📝 구현 설명
   - GamePlayer : 플레이어 고유정보(UID, Nickname), 플레이어 상태 정보 (플레이어 입장 준비, 현재 턴) 등 변수 선언
   - PlayerManager : GamePlayer에 Firebase UID 기준으로 등록하거나 조회 가능한 전역 싱글톤 클래스로 구현
 

### ❓구현 의도
   - 해당 방식으로 구현한 이유, 선택한 설계 방향 공유
  플레이어가 가지고 있는 데이터 관리 영역과 전역에서 플레이어의 정보를 조회할 수 있는 클래스가 필요하여 구현함
<br>

## ✅ PR 체크리스트
- [ ] 빌드 오류 없음
- [ ] 기능 정상 작동 확인
- [ ] 커밋 메시지 규칙 준수
- [ ] Scene 충돌 없음

## 💬 기타 사항
- 추후 Player 부분 마무리하시는 분은 LTH/feat-Player 브랜치에서 작업 이어가시면 됩니다!