### PR TITLE
[Feat] 게스트 로그인 - UID 연동 - 로비씬 이동 연동

### DIFF
--- a/Assets/KYG/KYG_Scene/New Scene.unity
+++ b/Assets/KYG/KYG_Scene/New Scene.unity
@@ -154,8 +154,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   defaultRegion: asia
-  autoLoadLobbyScene: 1
   lobbySceneName: LDH_MainScene
+  gameplaySceneName: PMS_ShootingTestScene
+  loadLobbyOnJoinedRoom: 1
 --- !u!4 &99408737
 Transform:
   m_ObjectHideFlags: 0
@@ -186,6 +187,7 @@ MonoBehaviour:
   buttonRoot: {fileID: 1051153008}
   guestLoginButton: {fileID: 1051153010}
   inputRoot: {fileID: 918197095}
+  loadingRoot: {fileID: 0}
   nicknameInput: {fileID: 918197097}
   hintText: {fileID: 1743124128}
   confirmButton: {fileID: 1811618704}
@@ -858,6 +860,50 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 918197095}
   m_CullTransparentMesh: 1
+--- !u!1 &923891975
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 923891977}
+  - component: {fileID: 923891976}
+  m_Layer: 0
+  m_Name: PlayerDirectory
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &923891976
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 923891975}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c5d59b450fe3a0f4ba63316e73e42389, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &923891977
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 923891975}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 833.4201, y: 2061.0193, z: -6.265757}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1051153008
 GameObject:
   m_ObjectHideFlags: 0
@@ -1193,6 +1239,50 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Padding: {x: -8, y: -5, z: -8, w: -5}
   m_Softness: {x: 0, y: 0}
+--- !u!1 &1522349951
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1522349953}
+  - component: {fileID: 1522349952}
+  m_Layer: 0
+  m_Name: UidPersistenceGuard
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1522349952
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1522349951}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd8a1414ad6ee984d994a9d31abec897, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1522349953
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1522349951}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 833.4201, y: 2061.0193, z: -6.265757}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1550354076
 GameObject:
   m_ObjectHideFlags: 0
@@ -1463,6 +1553,50 @@ MonoBehaviour:
     m_MipBias: 0
     m_VarianceClampScale: 0.9
     m_ContrastAdaptiveSharpening: 0
+--- !u!1 &1589312108
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1589312110}
+  - component: {fileID: 1589312109}
+  m_Layer: 0
+  m_Name: PlayerDirectoryBinder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1589312109
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1589312108}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 887bcf1fabfc2c34e9f20fa81bbd109b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1589312110
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1589312108}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 833.4201, y: 2061.0193, z: -6.265757}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1743124126
 GameObject:
   m_ObjectHideFlags: 0
@@ -2024,3 +2158,6 @@ SceneRoots:
   - {fileID: 590628686}
   - {fileID: 1974923859}
   - {fileID: 99408737}
+  - {fileID: 923891977}
+  - {fileID: 1589312110}
+  - {fileID: 1522349953}

--- a/Assets/KYG/KYG_Scripts/Auth/GuestLoginManager.cs
+++ b/Assets/KYG/KYG_Scripts/Auth/GuestLoginManager.cs
@@ -132,9 +132,9 @@ namespace KYG.Auth
             SafeReapplyUid();
 
             // 여기서 바로 룸 합류(혹은 만들기)
-            //var roomName = "DefaultRoom"; // 프로젝트 정책에 맞는 룸명/매칭 로직으로 바꾸세요.
-            //var options = new RoomOptions { MaxPlayers = 4 };
-            //PhotonNetwork.JoinOrCreateRoom(roomName, options, TypedLobby.Default);
+            var roomName = "LOBBY-MM"; // 프로젝트 규칙에 맞게
+            var options = new RoomOptions { MaxPlayers = 4, IsOpen = true, IsVisible = true };
+            PhotonNetwork.JoinOrCreateRoom(roomName, options, TypedLobby.Default);
         }
 
         public override void OnJoinedRoom()

--- a/Assets/KYG/KYG_Scripts/Auth/GuestLoginManager.cs
+++ b/Assets/KYG/KYG_Scripts/Auth/GuestLoginManager.cs
@@ -18,7 +18,7 @@ namespace KYG.Auth
         [SerializeField] private string defaultRegion = "asia";
 
         [Header("Scene Names")]
-        [SerializeField] private string lobbySceneName = "LobbyScene";            // 로비(대기) 씬 이름
+        [SerializeField] private string lobbySceneName = "LDH_MainScene";            // 로비(대기) 씬 이름
         [SerializeField] private string gameplaySceneName = "PMS_ShootingTestScene"; // 실제 게임 씬 (예시)
 
         [Header("Flow Options")]

--- a/Assets/KYG/KYG_Scripts/Auth/MiniGameUidExample.cs
+++ b/Assets/KYG/KYG_Scripts/Auth/MiniGameUidExample.cs
@@ -1,0 +1,39 @@
+using KYG.Net;        // PlayerDirectory
+using Photon.Pun;
+using Photon.Realtime;
+using UnityEngine;
+
+/// <summary>
+/// 미니게임 진입 시 내 UID/동료 UID를 확인하고, UID 기준으로 접근하는 샘플
+/// - 실제 게임 로직에서는 UID로 팀/슬롯/점수판/오너쉽 등 연결
+/// </summary>
+public class MiniGameUidExample : MonoBehaviour
+{
+    void Start()
+    {
+        var dir = PlayerDirectory.Instance;
+        if (dir == null)
+        {
+            Debug.LogWarning("[MiniGameUidExample] PlayerDirectory not found.");
+            return;
+        }
+
+        // 내 UID
+        string myUid = dir.LocalUid;
+        Debug.Log($"[MiniGameUidExample] My UID: {myUid}");
+
+        // 내 Photon Player 역조회
+        Player me = dir.GetPlayerByUid(myUid);
+        Debug.Log($"[MiniGameUidExample] My Player: #{me?.ActorNumber} {me?.NickName}");
+
+        // 다른 모든 플레이어 순회
+        foreach (var kv in dir.UidMap)
+        {
+            string uid = kv.Key;
+            Player p = kv.Value;
+            Debug.Log($"[MiniGameUidExample] UID:{uid} -> Player:{p?.NickName} (actor:{p?.ActorNumber})");
+        }
+
+        // 예: 특정 게임 오브젝트 디렉토리(별도 매니저)에서 UID로 소유자 오브젝트 찾기 등의 패턴으로 확장
+    }
+}

--- a/Assets/KYG/KYG_Scripts/Auth/MiniGameUidExample.cs.meta
+++ b/Assets/KYG/KYG_Scripts/Auth/MiniGameUidExample.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2688fd4f05f239c41a6a1d9843788cc2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KYG/KYG_Scripts/Auth/PlayerDirectory.cs
+++ b/Assets/KYG/KYG_Scripts/Auth/PlayerDirectory.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using Photon.Pun;
+using Photon.Realtime;
+using UnityEngine;
+
+namespace KYG.Net
+{
+    /// <summary>
+    /// UID 기준으로 Photon Player와 게임 내 객체를 매핑/조회하는 중앙 레지스트리
+    /// - OnJoinedRoom/OnPlayerEntered/Left 에서 갱신
+    /// - 게임 로직에서 UID만 알면 Player/슬롯/오너쉽 등을 역으로 찾을 수 있음
+    /// </summary>
+    public class PlayerDirectory : MonoBehaviour
+    {
+        public static PlayerDirectory Instance { get; private set; }
+        private void Awake()
+        {
+            if (Instance != null && Instance != this) { Destroy(gameObject); return; }
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        // UID -> Photon Player
+        private readonly Dictionary<string, Player> _uidToPlayer = new();
+        // ActorNumber -> UID (역조회)
+        private readonly Dictionary<int, string> _actorToUid = new();
+
+        public string LocalUid { get; private set; }  // 빠른 접근
+
+        public event Action<Player> RegistryChanged; // UI 리빌드 등에서 쓰기 편함
+
+        public void RebuildAll()
+        {
+            _uidToPlayer.Clear();
+            _actorToUid.Clear();
+
+            foreach (var p in PhotonNetwork.PlayerList)
+            {
+                var uid = p.GetUidSafe();
+                if (string.IsNullOrEmpty(uid)) continue;
+
+                _uidToPlayer[uid] = p;
+                _actorToUid[p.ActorNumber] = uid;
+            }
+
+            var localUid = PhotonNetwork.LocalPlayer?.GetUidSafe();
+            if (!string.IsNullOrEmpty(localUid)) LocalUid = localUid;
+
+            RegistryChanged?.Invoke(PhotonNetwork.LocalPlayer);
+        }
+
+        public void Upsert(Player p)
+        {
+            if (p == null) return;
+            var uid = p.GetUidSafe();
+            if (string.IsNullOrEmpty(uid)) return;
+
+            _uidToPlayer[uid] = p;
+            _actorToUid[p.ActorNumber] = uid;
+
+            if (p.IsLocal) LocalUid = uid;
+            RegistryChanged?.Invoke(p);
+        }
+
+        public void Remove(Player p)
+        {
+            if (p == null) return;
+            if (_actorToUid.TryGetValue(p.ActorNumber, out var uid))
+            {
+                _actorToUid.Remove(p.ActorNumber);
+                if (_uidToPlayer.TryGetValue(uid, out var cur) && cur == p)
+                    _uidToPlayer.Remove(uid);
+            }
+            RegistryChanged?.Invoke(p);
+        }
+
+        public Player GetPlayerByUid(string uid)
+            => string.IsNullOrEmpty(uid) ? null : (_uidToPlayer.TryGetValue(uid, out var p) ? p : null);
+
+        public string GetUidByActor(int actorNumber)
+            => _actorToUid.TryGetValue(actorNumber, out var uid) ? uid : null;
+
+        public IReadOnlyDictionary<string, Player> UidMap => _uidToPlayer;
+    }
+}

--- a/Assets/KYG/KYG_Scripts/Auth/PlayerDirectory.cs.meta
+++ b/Assets/KYG/KYG_Scripts/Auth/PlayerDirectory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c5d59b450fe3a0f4ba63316e73e42389
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KYG/KYG_Scripts/Auth/PlayerDirectoryBinder.cs
+++ b/Assets/KYG/KYG_Scripts/Auth/PlayerDirectoryBinder.cs
@@ -1,0 +1,54 @@
+using KYG.Net;            // PlayerDirectory
+using Photon.Pun;
+using Photon.Realtime;
+using UnityEngine;
+
+/// <summary>
+/// PlayerDirectory 를 Photon 이벤트에 자동 연동:
+/// - 방 입장: 전체 리빌드
+/// - 플레이어 입/퇴장: 업서트/삭제
+/// - 플레이어 프로퍼티 변경(특히 uid): 업서트
+/// - 방 퇴장: 맵 초기화(다음 룸 대비)
+/// </summary>
+public class PlayerDirectoryBinder : MonoBehaviourPunCallbacks
+{
+    private PlayerDirectory Dir => PlayerDirectory.Instance;
+
+    private static PlayerDirectoryBinder _instance;
+    void Awake()
+    {
+        if (_instance != null && _instance != this) { Destroy(gameObject); return; }
+        _instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    public override void OnJoinedRoom()
+    {
+        Dir?.RebuildAll();
+        Debug.Log("[PlayerDirectoryBinder] RebuildAll on JoinedRoom");
+    }
+
+    public override void OnLeftRoom()
+    {
+        Dir?.RebuildAll(); // 비움과 동일(플레이어 리스트 0)
+        Debug.Log("[PlayerDirectoryBinder] RebuildAll on LeftRoom");
+    }
+
+    public override void OnPlayerEnteredRoom(Player newPlayer)
+    {
+        Dir?.Upsert(newPlayer);
+        Debug.Log($"[PlayerDirectoryBinder] Upsert on Enter: {newPlayer?.NickName}");
+    }
+
+    public override void OnPlayerLeftRoom(Player otherPlayer)
+    {
+        Dir?.Remove(otherPlayer);
+        Debug.Log($"[PlayerDirectoryBinder] Remove on Left: {otherPlayer?.NickName}");
+    }
+
+    public override void OnPlayerPropertiesUpdate(Player targetPlayer, ExitGames.Client.Photon.Hashtable changedProps)
+    {
+        // uid/슬롯/레디 등 바뀌었을 때 UI 갱신이 자연스럽도록 항상 업서트
+        Dir?.Upsert(targetPlayer);
+    }
+}

--- a/Assets/KYG/KYG_Scripts/Auth/PlayerDirectoryBinder.cs.meta
+++ b/Assets/KYG/KYG_Scripts/Auth/PlayerDirectoryBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 887bcf1fabfc2c34e9f20fa81bbd109b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KYG/KYG_Scripts/Auth/UIDExtensions.cs
+++ b/Assets/KYG/KYG_Scripts/Auth/UIDExtensions.cs
@@ -1,0 +1,37 @@
+using Photon.Realtime;
+using ExitGames.Client.Photon;
+
+public static class UIDExtensions
+{
+    private const string UID_KEY = "uid";
+
+    /// <summary>Photon Player의 CustomProperties에서 uid를 안전하게 꺼냅니다.</summary>
+    public static string GetUidSafe(this Player p)
+    {
+        if (p == null) return null;
+        if (p.CustomProperties != null &&
+            p.CustomProperties.TryGetValue(UID_KEY, out var v) &&
+            v is string s && !string.IsNullOrEmpty(s))
+            return s;
+
+        // 보정: PUN이 AuthenticationValues.UserId 를 Player.UserId에 반영하는 경우가 있어, fallback으로 시도
+        if (!string.IsNullOrEmpty(p.UserId)) return p.UserId;
+
+        return null;
+    }
+
+    /// <summary>로컬만 사용. uid 누락 시 다시 셋업(GuestLoginManager.SafeReapplyUid와 동일 의도)</summary>
+    public static void EnsureLocalUid(this Player local, string uid)
+    {
+        if (local == null || string.IsNullOrEmpty(uid)) return;
+        var hasUid = local.CustomProperties != null &&
+                     local.CustomProperties.ContainsKey(UID_KEY) &&
+                     local.CustomProperties[UID_KEY] is string s &&
+                     !string.IsNullOrEmpty(s);
+        if (!hasUid)
+        {
+            var props = new Hashtable { { UID_KEY, uid } };
+            local.SetCustomProperties(props);
+        }
+    }
+}

--- a/Assets/KYG/KYG_Scripts/Auth/UIDExtensions.cs.meta
+++ b/Assets/KYG/KYG_Scripts/Auth/UIDExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b925365a6a2e644ab4db851679aa764
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KYG/KYG_Scripts/Auth/UidPersistenceGuard.cs
+++ b/Assets/KYG/KYG_Scripts/Auth/UidPersistenceGuard.cs
@@ -1,0 +1,65 @@
+using Photon.Pun;
+using Photon.Realtime;
+using UnityEngine;
+using KYG.Auth; // GuestLoginManager
+using ExitGames.Client.Photon;
+
+/// <summary>
+/// 전 씬 공통 UID 보정 가드:
+/// - 마스터 접속/로비 입장/룸 입장/속성변경 시 LocalPlayer의 uid 누락을 자동 보정
+/// - GuestLoginManager.SafeReapplyUid 와 같은 목적, but 전역 보강
+/// </summary>
+public class UidPersistenceGuard : MonoBehaviourPunCallbacks
+{
+    private const string UID_KEY = "uid";
+
+    private static UidPersistenceGuard _instance;
+    public static UidPersistenceGuard Instance => _instance;
+
+    void Awake()
+    {
+        if (_instance != null && _instance != this) { Destroy(gameObject); return; }
+        _instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    private void EnsureLocalUid()
+    {
+        var glm = GuestLoginManager.Instance; // Firebase 로그인 소스
+        var local = PhotonNetwork.LocalPlayer;
+
+        if (glm == null || local == null) return;
+
+        // Firebase의 userId가 있고, LocalPlayer 커스텀에 uid가 비어있다면 재주입
+        var user = typeof(GuestLoginManager)
+            .GetField("user", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            ?.GetValue(glm) as Firebase.Auth.FirebaseUser;
+
+        var uid = user?.UserId;
+        if (string.IsNullOrEmpty(uid)) return;
+
+        bool hasUid = local.CustomProperties != null &&
+                      local.CustomProperties.ContainsKey(UID_KEY) &&
+                      local.CustomProperties[UID_KEY] is string s &&
+                      !string.IsNullOrEmpty(s);
+
+        if (!hasUid)
+        {
+            var props = new Hashtable { { UID_KEY, uid } };
+            local.SetCustomProperties(props);
+            // Photon NickName도 보정 (선택)
+            // if (!string.IsNullOrEmpty(user.DisplayName)) PhotonNetwork.NickName = user.DisplayName;
+
+            Debug.Log("[UidPersistenceGuard] Reapplied uid to LocalPlayer.");
+        }
+    }
+
+    public override void OnConnectedToMaster() => EnsureLocalUid();
+    public override void OnJoinedLobby() => EnsureLocalUid();
+    public override void OnJoinedRoom() => EnsureLocalUid();
+    public override void OnPlayerPropertiesUpdate(Player targetPlayer, Hashtable changedProps)
+    {
+        if (targetPlayer != null && targetPlayer.IsLocal && changedProps != null && changedProps.ContainsKey(UID_KEY))
+            EnsureLocalUid();
+    }
+}

--- a/Assets/KYG/KYG_Scripts/Auth/UidPersistenceGuard.cs.meta
+++ b/Assets/KYG/KYG_Scripts/Auth/UidPersistenceGuard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd8a1414ad6ee984d994a9d31abec897
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LDH/LDH_Scripts/Network/MatchMaking.cs
+++ b/Assets/LDH/LDH_Scripts/Network/MatchMaking.cs
@@ -20,6 +20,8 @@ namespace Network
         
         [SerializeField] private bool autoSyncScene = true;
         
+        [SerializeField] private bool autoConnectOnAwake = false;
+        
         private MatchType _createType = MatchType.None;
         //--- private matching ---- 
         private int _privateRetryCount;
@@ -53,6 +55,7 @@ namespace Network
             PhotonNetwork.AutomaticallySyncScene = autoSyncScene;
 
             //임시로 awake 시점에 호출
+            if (autoConnectOnAwake)
             ConnectServer();
         }
 

--- a/Assets/Plugins/Android/FirebaseCrashlytics.androidlib/res/values/crashlytics_build_id.xml
+++ b/Assets/Plugins/Android/FirebaseCrashlytics.androidlib/res/values/crashlytics_build_id.xml
@@ -1,1 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?><resources><string name="com.crashlytics.android.build_id" translatable="false">a7c9f754-ca86-4281-8426-c70ec4deeed3</string></resources>
+<?xml version="1.0" encoding="utf-8"?><resources><string name="com.crashlytics.android.build_id" translatable="false">204c6a3c-71bc-4d1a-89d6-abbf37ab77ac</string></resources>

--- a/Assets/Plugins/Android/FirebaseCrashlytics.androidlib/res/values/crashlytics_build_id.xml
+++ b/Assets/Plugins/Android/FirebaseCrashlytics.androidlib/res/values/crashlytics_build_id.xml
@@ -1,1 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?><resources><string name="com.crashlytics.android.build_id" translatable="false">9afbe0e8-901b-41c5-8296-8f6e783fa29c</string></resources>
+<?xml version="1.0" encoding="utf-8"?><resources><string name="com.crashlytics.android.build_id" translatable="false">a7c9f754-ca86-4281-8426-c70ec4deeed3</string></resources>


### PR DESCRIPTION
# 🧑‍💻 PR

## 🔗 관련 이슈
- 수행한 작업과 관련 작업 번호를 작성해주세요 

Resolves: #?? (UID 연동 및 게스트 로그인 관련)

Related to: #?? (미니게임 씬 UID 연동)

<!--
- Resolves: #25 => PR 머지 시 해당 이슈 자동 닫힘
- Related to: #25 => 단순 연결, 자동 닫힘 없음
-->

## 🔥 작업 내용 요약

Feat - UidPersistenceGuard 추가 (씬 전환 후에도 UID 유지)

Feat - PlayerDirectoryBinder 구현 (플레이어 UID → Player 객체 매핑)

Feat - MiniGameUidExample 샘플 코드 추가 (미니게임에서도 UID 확인 가능)

Refactor - GuestLoginManager 일부 리팩토링 (UID 전달 방식 개선)

Scene - New Scene.unity 테스트 씬 추가

<!--
1. Feat - 플레이어 이동 구현
2. Fix - 아이템 복사 버그 수정
3. Comment - GameManager 코드 주석 설명 추가
-->
<br>

## 💻 작업 구현 방법 (공통)
### 📝 구현 설명
   - 어떤 방식으로 구현했는지, 주요 로직과 처리 방식 설명

Firebase Guest 로그인 후 UID를 획득하고, Photon 플레이어와 연동되도록 개선

UidPersistenceGuard를 통해 씬 이동 후에도 UID가 유지되도록 구현

PlayerDirectoryBinder를 사용하여 UID로 GamePlayer 객체를 찾을 수 있도록 매핑

MiniGameUidExample 씬에서 UID 기반으로 플레이어 상태를 확인하는 샘플 작성

  <!--
   - 예) 횡스크롤 이동 방식을 채택하여 좌우 키 입력에 따라 Rigidbody를 이동
  -->

### ❓구현 의도
   - 해당 방식으로 구현한 이유, 선택한 설계 방향 공유 

로그인/로비/미니게임 전환 시 UID가 끊기지 않고 유지되도록 하기 위함

추후 여러 미니게임에서도 공통적으로 UID를 기준으로 플레이어를 식별할 수 있도록 구조화

### 🔊 특이사항
   - 주의해야 할 점 (중요 변경 사항 요약)

GuestLoginManager 내 UID 전달 로직 수정됨 → 기존 참조 코드 충돌 가능성 있음

씬 이동 시 UID 유지가 안되던 문제 해결됨

<!--
   - 예) 플레이어가 아이템을 줍지 않아서 PlayerController 코드 부분에 수정이 있었습니다. 코드 충돌 우려됩니다.
 -->

<br>

## 💻 버그 해결방법 (Fix 전용)

### 🔧 수정된 버그

씬 이동 시 UID 초기화 문제

<!--
예) 아이템 호버링, 사운드 누락
-->

### 💡 해결방법
- 어떠한 방식을 해결을 했는지 설명

DontDestroyOnLoad 및 UidPersistenceGuard 적용

PlayerDirectory 매핑 방식 보완

### ✔️ 버그 체크리스트
- [ ] 추가로 수정이 필요함
- [ ] 수정 완료
- [ ] QA 테스트 통과

### 💬 기타 사항
- 수정이 안된 경우 필요한 작업이 뭔지 진행 상황 공유

GuestLoginManager가 여러 씬에서 중복 생성되지 않도록 주의 필요

UidPersistenceGuard는 Singleton 성격이 강하므로 중복 생성을 방지해야 함

매치메이킹 씬에서 방 생성이 안되는 버그 발생
<!--
예) 아이템 중복 버그 → 수정 중 (RPC 권한 마스터로 위임으로 수정 중)
-->

## ✅ PR 체크리스트
- [ ] 빌드 오류 없음
- [ ] 기능 정상 작동 확인
- [ ] 커밋 메시지 규칙 준수
- [ ] Scene 충돌 없음

## 💬 기타 사항
- 리뷰어에게 공유하고 싶은 내용