### PR TITLE
[QA][Fix] 빠른 매칭 중단후 재매칭 오류, ready ui 잔존 오류, ready ui 깜박임 현상

### DIFF
--- a/Assets/KYG/KYG_Scripts/Auth/GuestLoginManager.cs
+++ b/Assets/KYG/KYG_Scripts/Auth/GuestLoginManager.cs
@@ -5,6 +5,7 @@ using Firebase.Extensions;
 using Photon.Pun;
 using Photon.Realtime;
 using ExitGames.Client.Photon;
+using Managers;
 using UnityEngine;
 using UnityEngine.SceneManagement; // 필요시
 
@@ -103,6 +104,8 @@ namespace KYG.Auth
             //닉네임과 아이디만 설정해준다
             PhotonNetwork.NickName = nickname;
             PhotonNetwork.AuthValues = new AuthenticationValues(uid);
+            
+            Manager.Network.SetAuthReady();
 
             //---- 커스텀 프로퍼티는 로비 입장 후 설정되는 것으로 옮김 (공통적용을 위해)---- 0829(이도현)
             // var props = new Hashtable { { "uid", uid } };
@@ -113,11 +116,6 @@ namespace KYG.Auth
             {
                 PhotonNetwork.ConnectUsingSettings();
                 Debug.Log("[GuestLoginManager] Connecting to Photon...");
-            }
-            else
-            {
-                if (!PhotonNetwork.InLobby)
-                    PhotonNetwork.JoinLobby();
             }
         }
 
@@ -132,7 +130,7 @@ namespace KYG.Auth
                 return;
             }
             
-            PhotonNetwork.JoinLobby();
+         
         }
         
         // ----- NetworkManager로 기능 통합 ----- 0829(이도현)

--- a/Assets/LDH/LDH_Scenes/LDH_MainScene.unity
+++ b/Assets/LDH/LDH_Scenes/LDH_MainScene.unity
@@ -824,12 +824,12 @@ PrefabInstance:
     - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 2.2156863
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1.0713073
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
         type: 3}

--- a/Assets/LDH/LDH_Scripts/MainGame/MainGameManager/MainGameManager.cs
+++ b/Assets/LDH/LDH_Scripts/MainGame/MainGameManager/MainGameManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using Cysharp.Threading.Tasks;
 using DesignPattern;
 using JetBrains.Annotations;
@@ -57,7 +58,7 @@ namespace LDH_MainGame
 
             base.OnAwake();
         }
-
+        
         public void  Initialize()
         {
             Util_LDH.ConsoleLog(this, "MainGameManager 초기화 로직 실행");
@@ -140,7 +141,7 @@ namespace LDH_MainGame
             int readyMask = PropertiesCtrl.BuildReadyMaskFromPlayers();
             UI.UpdateReady(readyMask);
 
-            if (IsMaster)
+            if (IsMaster && PhotonNetwork.CurrentRoom!=null && PhotonNetwork.CurrentRoom.PlayerCount>1)
             {
                 if (changedProps.ContainsKey(PlayerProps.InGameReady) &&
                     FSM.Get() == MainState.Ready &&
@@ -158,8 +159,23 @@ namespace LDH_MainGame
 
         public override void OnPlayerLeftRoom(Player otherPlayer)
         {
+            //현재 room이 아니거나, joined 상태가 아니거나, leaving room 중이라면 패스
             if (!PhotonNetwork.InRoom || PhotonNetwork.NetworkClientState != ClientState.Joined ||
                 _isLeavingRoom) return;
+            
+            // 현재 방 가져오기
+            var room = PhotonNetwork.CurrentRoom;
+            if (room == null) return;   // 방이 없다면 패스
+            
+            // 1) 혼자 남았다면 강제 게임 종료 처리
+            if (room.PlayerCount == 1)
+            {
+                UI.ShowQuitPopup();
+                return;
+            }
+            
+            
+            // 2) 마스터 클라이언트이고, 메인 게임 상태가 ready(모든 플레이어의 ready를 기다리고 있는 상태)라면 재조정
             if (!IsMaster) return;
             if (FSM.Get() != MainState.Ready) return;
 
@@ -168,15 +184,23 @@ namespace LDH_MainGame
             {
                 PropertiesCtrl.SetRoomProps(RoomProps.State, MainState.LoadingMiniGame.ToString());
             }
-
-            // UI 갱신
-            UI.UpdateReady(PropertiesCtrl.BuildReadyMaskFromPlayers());
+           
         }
 
         public override void OnMasterClientSwitched(Player newMasterClient)
         {
             if (!IsMaster) return;
 
+            //새로 마스터가 된 플레이어의 슬롯을 재배정한다.(0번으로)
+            if (newMasterClient.IsLocal)
+            {
+                Debug.Log("[MainGameManager] 새롭게 마스터가 된 클라이언트의 슬롯 인덱스를 갱신합니다. : 0번 슬롯으로");
+                MainGame_PropertiesController.SetSlotIndex(0);
+                _localSlot = 0;
+
+            }
+            
+            
             if (FSM.Get() == MainState.Ready && PropertiesCtrl.AllPlayersReady())
             {
                 PropertiesCtrl.SetRoomProps(RoomProps.State, MainState.LoadingMiniGame.ToString());
@@ -233,16 +257,29 @@ namespace LDH_MainGame
                     _stateRoutine = StartCoroutine(FSM.Co_ApplyingResult(OnEndMiniGame));
                     break;
                 case MainState.End:
-                    _stateRoutine = StartCoroutine(Co_EndGame());
+                    _stateRoutine = null;
+                    EndGameAsync().Forget();
                     break;
             }
         }
 
 
-        private IEnumerator Co_EndGame()
+        public async UniTask EndGameAsync(bool force = false, CancellationToken ct = default)
         {
-            yield return FSM.Co_End(OnEndGame);
             _isLeavingRoom = true;
+            
+            if(!force)
+                await FSM.Co_End(OnEndGame).ToUniTask(cancellationToken: ct);
+            
+            // 병렬 실행
+            var unloadTask = MiniGameLoader.UnloadAdditive().ToUniTask(cancellationToken: ct);
+            var closeAllTask = Manager.UI.CloseAllPopupUI(); // 내부는 순차 닫기 유지
+
+            await UniTask.WhenAll(unloadTask, closeAllTask);
+            await UniTask.Yield(PlayerLoopTiming.LastPostLateUpdate, ct);
+
+            Debug.Log("[MainGameManager] After close all popup ui, leave room");
+       
             PhotonNetwork.LeaveRoom();
         }
 

--- a/Assets/LDH/LDH_Scripts/MainGame/MainGameManager/MainGameManager.cs
+++ b/Assets/LDH/LDH_Scripts/MainGame/MainGameManager/MainGameManager.cs
@@ -1,11 +1,8 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using DesignPattern;
-using JetBrains.Annotations;
-using LDH_UI;
 using LDH_Util;
 using Managers;
 using Photon.Pun;

--- a/Assets/LDH/LDH_Scripts/MainGame/MainGameManager/MainGame_PropertiesController.cs
+++ b/Assets/LDH/LDH_Scripts/MainGame/MainGameManager/MainGame_PropertiesController.cs
@@ -78,6 +78,11 @@ namespace LDH_MainGame
                    v is bool b && b;
         }
 
+        public static void SetSlotIndex(int newSlotIndex)
+        {
+            PhotonNetwork.LocalPlayer.SetCustomProperties(new Hashtable { { PP.SlotIndex, newSlotIndex } });
+        }
+
         public static void SetLocalReady(bool ready)
         {
             PhotonNetwork.LocalPlayer?.SetCustomProperties(new Hashtable { { PP.InGameReady, ready } });

--- a/Assets/LDH/LDH_Scripts/MainGame/MainGameManager/MainGame_StateMachine.cs
+++ b/Assets/LDH/LDH_Scripts/MainGame/MainGameManager/MainGame_StateMachine.cs
@@ -90,27 +90,10 @@ namespace LDH_MainGame
             _currentMini = string.IsNullOrEmpty(id) ? null : _registry.Get(id);
             if (_currentMini != null)
                 _uiBinder.BuildReadyPanel(_currentMini, PhotonNetwork.PlayerList, _isMaster(), out _);
-
-            // // 마스터가 모두 준비되면 로딩으로
-            // while (_state == MainState.Ready)
-            // {
-            //     if (_isMaster())
-            //     {
-            //         if (_pc.AllPlayersReady())
-            //         {
-            //             _pc.SetRoomProps(new Dictionary<string, object> {
-            //                 { RoomProps.State, MainState.LoadingMiniGame.ToString() }
-            //             });
-            //             break;
-            //         }
-            //     }
-            //     yield return null;
-            // }
         }
 
         public IEnumerator Co_LoadingMini(Action onLoadingMiniGame = null)
         {
-            
             
             if (_currentMini == null)
             {

--- a/Assets/LDH/LDH_Scripts/MainGame/MainGameManager/MainGame_StateMachine.cs
+++ b/Assets/LDH/LDH_Scripts/MainGame/MainGameManager/MainGame_StateMachine.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
 using LDH_Util;
 using Photon.Pun;
 using UnityEngine;
@@ -118,10 +119,11 @@ namespace LDH_MainGame
                 yield break;
             }
 
+            yield return _uiBinder.CloseReadyPanel().ToCoroutine();
+            
             // Additive Load
             yield return MiniGameLoader.LoadAdditive(_sceneName(_currentMini), null);
-
-            _uiBinder.CloseReadyPanel();
+          
             if (_isMaster())
                 _pc.SetRoomProps(RoomProps.State, MainState.PlayingMiniGame.ToString());
             

--- a/Assets/LDH/LDH_Scripts/MainGame/MainGameManager/MainGame_UIBinder.cs
+++ b/Assets/LDH/LDH_Scripts/MainGame/MainGameManager/MainGame_UIBinder.cs
@@ -16,6 +16,7 @@ namespace LDH_MainGame
         
         private UI_Popup_PrivateRoom _readyPanel;
         private UI_GameInfo _gameInfo;
+        private UI_Popup_QuitGame _quitPopup;
         
         // 생성자
         // 생성자
@@ -72,6 +73,27 @@ namespace LDH_MainGame
             _readyPanel = null; _gameInfo = null;
         }
 
+
+
+        #region 게임 강제 종료 팝업
+        public void ShowQuitPopup()
+        {
+            if (_quitPopup != null) return;
+            _quitPopup = Manager.UI.CreatePopupUI<UI_Popup_QuitGame>();
+            Manager.UI.ShowPopupUI(_quitPopup).Forget();
+        }
+
+        public void CloseQuitPopup()
+        {
+            if(_quitPopup == null) return;
+            Manager.UI.ClosePopupUI(_quitPopup).Forget();
+            _quitPopup = null;
+        }
+        
+
+        #endregion
+
+        
 
     }
 }

--- a/Assets/LDH/LDH_Scripts/MainGame/MainGameManager/MainGame_UIBinder.cs
+++ b/Assets/LDH/LDH_Scripts/MainGame/MainGameManager/MainGame_UIBinder.cs
@@ -58,7 +58,7 @@ namespace LDH_MainGame
         
         public void UpdateReady(int mask) => _readyPanel?.UpdateReadyByMask(mask);
 
-        public void CloseReadyPanel()
+        public async UniTask CloseReadyPanel()
         {
             if (_readyPanel == null)
             {
@@ -68,7 +68,7 @@ namespace LDH_MainGame
             foreach (var panel in _readyPanel.PlayerPanels)
                 if (panel != null) panel.ReadyClicked -= _onClickReady;
 
-            UniTask.Void(async () => { await Manager.UI.ClosePopupUI(_readyPanel); });
+            await Manager.UI.ClosePopupUI(_readyPanel); // 패널 닫힐 때까지 기다리기
             _readyPanel = null; _gameInfo = null;
         }
 

--- a/Assets/LDH/LDH_Scripts/MainGame/MiniGame/MiniGameLoader.cs
+++ b/Assets/LDH/LDH_Scripts/MainGame/MiniGame/MiniGameLoader.cs
@@ -42,12 +42,12 @@ namespace LDH_MainGame
         
         public static IEnumerator UnloadAdditive()
         {
-            if (_hasMiniScene)
-            {
-                var op = SceneManager.UnloadSceneAsync(_loadedMiniScene);
-                while (!op.isDone) yield return null;
-                _hasMiniScene = false;
-            }
+            if (!_hasMiniScene) yield break;
+            
+            var op = SceneManager.UnloadSceneAsync(_loadedMiniScene);
+            while (!op.isDone) yield return null;
+            _hasMiniScene = false;
+            
             
             // 메인 씬 컴포넌트 복원
             foreach (var b in _disabledOnMain.Where(b => b != null))

--- a/Assets/LDH/LDH_Scripts/MainGame/MiniGame/MiniGameLoader.cs
+++ b/Assets/LDH/LDH_Scripts/MainGame/MiniGame/MiniGameLoader.cs
@@ -20,23 +20,29 @@ namespace LDH_MainGame
             // 메인 씬 컴포넌트 중 비활성화 할 컴포넌트 처리
             var mainScene = SceneManager.GetActiveScene();
             _disabledOnMain.Clear();
-            Disable<Camera>(mainScene);
-            Disable<AudioListener>(mainScene);
-            Disable<EventSystem>(mainScene); 
-            
+            // Disable<Camera>(mainScene);
+            // Disable<AudioListener>(mainScene);
+            // Disable<EventSystem>(mainScene); 
             
             var op = SceneManager.LoadSceneAsync(sceneName, LoadSceneMode.Additive);
+            
             while (!op.isDone) yield return null;
 
             _loadedMiniScene = SceneManager.GetSceneByName(sceneName);
             _hasMiniScene = _loadedMiniScene.IsValid();
 
+            Disable<Camera>(mainScene);
+            Disable<AudioListener>(mainScene);
+            Disable<EventSystem>(mainScene); 
+            
             if (_hasMiniScene)
             {
                 Debug.Log("미니게임 씬 활성화 시점");
                 SceneManager.SetActiveScene(_loadedMiniScene);
             }
             
+          
+
             onReady?.Invoke();
         }
         

--- a/Assets/LDH/LDH_Scripts/Network/MatchController.cs
+++ b/Assets/LDH/LDH_Scripts/Network/MatchController.cs
@@ -78,6 +78,8 @@ namespace Network
         private void RefreshButtons()
         {
             bool ready = ReadyToMatch();
+            
+            //Debug.Log($"[MatchController] isconnected :{PhotonNetwork.IsConnected} / inlobby : {PhotonNetwork.InLobby} / inroom : {PhotonNetwork.InRoom} / is maching : {IsMatching} ");
             QuickMatch?.SetButtonInteractable(ready);
             PrivateMatch?.SetButtonInteractable(ready);
         }

--- a/Assets/LDH/LDH_Scripts/Network/MatchController.cs
+++ b/Assets/LDH/LDH_Scripts/Network/MatchController.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using LDH_Util;
 using Managers;
 using Photon.Pun;
+using Photon.Realtime;
 using UnityEngine;
 using Hashtable = ExitGames.Client.Photon.Hashtable;
 using static LDH_Util.Define_LDH;
@@ -16,11 +17,10 @@ namespace Network
         
         // 매칭 모드
         public MatchType CurrentMatchType { get; private set; } = MatchType.None;
-        
         public bool IsMatching { get; private set; }
         public event Action<MatchType, bool> MatchTypeChanged;
         
-
+        
         [Header("Match Controller")]
         public QuickMatchController QuickMatch;
         public PrivateMatchController PrivateMatch;
@@ -34,23 +34,57 @@ namespace Network
         private void Start()
         {
             QuickMatch ??= GetComponent<QuickMatchController>();
-
             PrivateMatch ??= GetComponent<PrivateMatchController>();
+            
+            Subscribe();
         }
+
+        private void OnDestroy() => Unsubscribe();
+
+        private void Subscribe()
+        {
+            PhotonNetwork.NetworkingClient.StateChanged += OnPhotonStateChanged;
+        }
+
+        private void Unsubscribe()
+        {
+            PhotonNetwork.NetworkingClient.StateChanged -= OnPhotonStateChanged;
+
+        }
+
 
         public void SetMatching(MatchType type, bool isMatching)
         {
             IsMatching = isMatching;
             CurrentMatchType = type;
             
-            QuickMatch?.SetButtonInteractable(!isMatching);
-            PrivateMatch?.SetButtonInteractable(!isMatching);
-            
             MatchTypeChanged?.Invoke(type, isMatching);
+            RefreshButtons();
         }
 
+        
+        
+        #region Matching Button Control
+
+        private void OnPhotonStateChanged(ClientState prev, ClientState curr)
+        {
+            RefreshButtons();
+        }   
 
 
+        private bool ReadyToMatch() =>
+            PhotonNetwork.IsConnected && PhotonNetwork.InLobby && !PhotonNetwork.InRoom && !IsMatching;
+
+        private void RefreshButtons()
+        {
+            bool ready = ReadyToMatch();
+            QuickMatch?.SetButtonInteractable(ready);
+            PrivateMatch?.SetButtonInteractable(ready);
+        }
+
+        #endregion
+        
+ 
         #region Game Start Logic
 
         /// 방 상태를 Complete로 전파하고(취소 불가), 짧은 지연 후 씬 로드.

--- a/Assets/LDH/LDH_Scripts/Network/NetworkManager.cs
+++ b/Assets/LDH/LDH_Scripts/Network/NetworkManager.cs
@@ -77,7 +77,7 @@ namespace Network
                 PhotonNetwork.ConnectUsingSettings();
             else
             {
-                RequestToJoinLobby();
+                TryJoinLobby();
             }
 #endif
         }

--- a/Assets/LDH/LDH_Scripts/Network/NetworkManager.cs
+++ b/Assets/LDH/LDH_Scripts/Network/NetworkManager.cs
@@ -21,14 +21,14 @@ namespace Network
 
         [SerializeField] private bool autoSyncScene = true;
 
-        [SerializeField] private bool autoConnectOnAwake = false;
-
-        private MatchType _createType = MatchType.None;
+        // ---- 인증 여부, 로비 진입과 관련 플래그
+        private bool _authReady = false;
 
         //--- private matching ---- 
+        private MatchType _createType = MatchType.None;
         private int _privateRetryCount;
-
         private bool _isNavigating = false;
+
 
         #region Events
 
@@ -66,23 +66,20 @@ namespace Network
         }
 
 
-        //필요한 시점에 호출하기 
-        //구글 로그인 성공 후 메인 씬으로 이동하기 전에 진행하면 될 것으로 판단
+        #region Connect Server(로그인 없이 게임 테스트 시 사용할 메서드)
+
         public void ConnectServer()
         {
-            
 #if TEST_WITHOUT_LOGIN
             SetTestNicknameAndID();
-#endif
             
             if (!PhotonNetwork.IsConnected)
                 PhotonNetwork.ConnectUsingSettings();
             else
             {
-                if (PhotonNetwork.IsConnectedAndReady &&!PhotonNetwork.InLobby)
-                    PhotonNetwork.JoinLobby();
+                RequestToJoinLobby();
             }
-
+#endif
         }
 
         // 임시 추가
@@ -96,7 +93,45 @@ namespace Network
 
             //아이디 = 닉네임이랑 똑같은 아이디로 부여
             PhotonNetwork.AuthValues = new AuthenticationValues(PhotonNetwork.NickName);
+
+
+            SetAuthReady();
         }
+
+        #endregion
+
+
+        #region Lobby 진입 관련 로직
+
+        //파이어베이스 로그인 완료 시점에서 호출하면 됨
+        public void SetAuthReady(bool ready = true) => _authReady = ready;
+
+
+        private void TryJoinLobby()
+        {
+            if (!PhotonNetwork.IsConnectedAndReady)
+            {
+                Debug.Log("[NetworkManager] 서버에 연결이 완료되지 않았습니다.");
+                return; // 마스터에 아직 연결 안 됐으면 대기
+            }
+
+            if (!_authReady)
+            {
+                Debug.Log("[NetworkManager] 파이어베이스 인증이 완료되지 않았습니다.");
+                return; // 인증 완료 안됐으면 대기
+            }
+
+            if (PhotonNetwork.InLobby || PhotonNetwork.InRoom)
+            {
+                Debug.Log("[NetworkManager] 이미 로비거나 현재 룸에 들어온 상태입니다.");
+                return;
+            }
+
+            Debug.Log("[NetworkManager] TryJoinLobby -> JoinLobby()");
+            PhotonNetwork.JoinLobby();
+        }
+
+        #endregion
 
 
         #region Quick Matching API
@@ -229,10 +264,7 @@ namespace Network
         public override void OnConnectedToMaster()
         {
             Debug.Log("[NetworkManager] 마스터 서버에 연결 완료");
-
-            if (PhotonNetwork.IsConnectedAndReady && !PhotonNetwork.InLobby)
-                PhotonNetwork.JoinLobby();
-
+            TryJoinLobby(); // 로비로 가겠다는 요청이 아니므로 tryjoinlobby를 사용. 로비로 가겠다는 요청이 있었다면 로비로 진입하고 없었다면 로비로 진입하지 않음.
             ConnectedToMaster?.Invoke();
         }
 
@@ -260,7 +292,8 @@ namespace Network
                 var props = new Hashtable { { "uid", PhotonNetwork.AuthValues?.UserId }, };
                 PhotonNetwork.LocalPlayer.SetCustomProperties(props);
             }
-            
+
+
             var current = SceneManager.GetActiveScene().name;
             if (!string.Equals(current, lobbySceneName, System.StringComparison.Ordinal) && !_isNavigating)
             {
@@ -271,6 +304,7 @@ namespace Network
             {
                 Debug.Log("[NetworkManager] 현재 로비 씬입니다.");
             }
+
 
             JoinedLobby?.Invoke();
         }
@@ -304,9 +338,8 @@ namespace Network
         {
             Debug.Log($"[NetworkManager] 비공개 방 입장에 실패했습니다. ({returnCode}) {message}");
             JoinFailed?.Invoke(returnCode, message);
-            
-            if (PhotonNetwork.IsConnectedAndReady && !PhotonNetwork.InLobby)
-                PhotonNetwork.JoinLobby();
+
+            TryJoinLobby();
         }
 
         #endregion
@@ -319,8 +352,10 @@ namespace Network
 
             PlayerManager.Instance.ClearAllPlayers();
             ClearAllPlayerProperty();
-
             LeftRoom?.Invoke();
+
+            //로비로 복귀 시도
+            TryJoinLobby();
         }
 
         #endregion

--- a/Assets/LDH/LDH_Scripts/Network/NetworkManager.cs
+++ b/Assets/LDH/LDH_Scripts/Network/NetworkManager.cs
@@ -305,6 +305,9 @@ namespace Network
         {
             Debug.Log($"[NetworkManager] 비공개 방 입장에 실패했습니다. ({returnCode}) {message}");
             JoinFailed?.Invoke(returnCode, message);
+            
+            if (PhotonNetwork.IsConnectedAndReady && !PhotonNetwork.InLobby)
+                PhotonNetwork.JoinLobby();
         }
 
         #endregion

--- a/Assets/LDH/LDH_Scripts/Network/NetworkManager.cs
+++ b/Assets/LDH/LDH_Scripts/Network/NetworkManager.cs
@@ -230,9 +230,8 @@ namespace Network
         {
             Debug.Log("[NetworkManager] 마스터 서버에 연결 완료");
 
-#if TEST_WITHOUT_LOGIN
-            PhotonNetwork.JoinLobby();
-#endif
+            if (PhotonNetwork.IsConnectedAndReady && !PhotonNetwork.InLobby)
+                PhotonNetwork.JoinLobby();
 
             ConnectedToMaster?.Invoke();
         }

--- a/Assets/LDH/LDH_Scripts/Test/MainGameDebugPanel.cs
+++ b/Assets/LDH/LDH_Scripts/Test/MainGameDebugPanel.cs
@@ -41,7 +41,11 @@ namespace LDH.LDH_Scripts.Test
             };
 
             MainGameManager.Instance.OnWaitAllReady += () => logText.gameObject.SetActive(false);
-            MainGameManager.Instance.OnLoadingMiniGame += () => gameObject.SetActive(false);
+            MainGameManager.Instance.OnLoadingMiniGame += () =>
+            {
+                Debug.Log("[MainGameDebugPanel] 미니게임 진입. 디버그 패널을 안보이게 설정합니다.");
+                gameObject.SetActive(false);
+            };
             MainGameManager.Instance.OnEndMiniGame += () => gameObject.SetActive(true);
             
             MainGameManager.Instance.OnEndGame += () =>

--- a/Assets/LDH/LDH_Scripts/Test/UITestScript.cs
+++ b/Assets/LDH/LDH_Scripts/Test/UITestScript.cs
@@ -30,7 +30,6 @@ namespace LDH.LDH_Scripts.Test
 
         private void UpdatePlayerInfo()
         {
-            Debug.Log("dafasf");
             playerInfoText.text = $"Player ID : {PhotonNetwork.LocalPlayer.CustomProperties["uid"].ToString()} \n\nPlayer NickName :{PhotonNetwork.NickName}";
         }
     }

--- a/Assets/LDH/LDH_Scripts/UI/01_Popup/UI_Popup.cs
+++ b/Assets/LDH/LDH_Scripts/UI/01_Popup/UI_Popup.cs
@@ -23,6 +23,10 @@ namespace LDH_UI
                 cg.alpha = Mathf.Clamp01(t / fadeTime);
                 await UniTask.Yield(ct);
             }
+            
+            cg.alpha = 1f;
+            cg.blocksRaycasts = true;
+            cg.interactable = true;
         }
 
 
@@ -36,6 +40,11 @@ namespace LDH_UI
                 cg.alpha = 1f - Mathf.Clamp01(t / fadeTime);
                 await UniTask.Yield(ct);
             }
+            
+            cg.alpha = 0f;
+            cg.blocksRaycasts = false;
+            cg.interactable = false;
+            gameObject.SetActive(false);
         }
 
         #endregion
@@ -58,9 +67,7 @@ namespace LDH_UI
                 return; // 팝업이 파괴되면 자연스레 취소됨
             }
 
-            // UI 매니저의 표준 닫기 흐름을 타고 싶으면 RequestClose()가 안전
-            UniTask.Void(async () => { await Manager.UI.ClosePopupUI(this); });
-
+            await Manager.UI.ClosePopupUI(this);
         }
     }
 }

--- a/Assets/LDH/LDH_Scripts/UI/01_Popup/UI_Popup_QuitGame.cs
+++ b/Assets/LDH/LDH_Scripts/UI/01_Popup/UI_Popup_QuitGame.cs
@@ -1,0 +1,29 @@
+using System;
+using Cysharp.Threading.Tasks;
+using LDH_MainGame;
+using Managers;
+using Photon.Pun;
+using UnityEngine;
+using UnityEngine.InputSystem.HID;
+using UnityEngine.UI;
+
+namespace LDH_UI
+{
+    public class UI_Popup_QuitGame : UI_Popup
+    {
+        [SerializeField] private Button okButton;
+
+        private void Awake()
+        {
+            okButton?.onClick.AddListener(QuitGame);
+        }
+
+        private void QuitGame()
+        {
+            Debug.Log("Quit Game");
+            okButton.interactable = false;
+            // StartCoroutine(MainGameManager.Instance.Co_EndGame(true));
+            MainGameManager.Instance.EndGameAsync().Forget();
+        }
+    }
+}

--- a/Assets/LDH/LDH_Scripts/UI/01_Popup/UI_Popup_QuitGame.cs.meta
+++ b/Assets/LDH/LDH_Scripts/UI/01_Popup/UI_Popup_QuitGame.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ebccc9ce335743cf9e5b98505b235fd1
+timeCreated: 1756715586

--- a/Assets/LDH/LDH_Scripts/UI/UIManager.cs
+++ b/Assets/LDH/LDH_Scripts/UI/UIManager.cs
@@ -25,6 +25,7 @@ namespace LDH_UI
 
         private readonly Stack<UI_Popup> _popupStack = new(); // 팝업 UI Stack
         private readonly Dictionary<Type, UI_Base> _screenCache = new(); // Screen 풀
+        private readonly HashSet<UI_Popup> _closing = new();
 
         //---- toast ui ---- //
         private UI_Toast _toast; // 1개 재사용
@@ -40,6 +41,11 @@ namespace LDH_UI
         [SerializeField] private string screenFolder = "Prefabs/UI/Screen";
         [SerializeField] private string popupFolder = "Prefabs/UI/Popup";
         [SerializeField] private string toastFolder = "Prefabs/UI/Toast";
+        
+        
+        //---- flag ------ //
+        private bool _isClosingAllPopups;
+
 
         protected override void OnAwake() => Init();
 
@@ -245,11 +251,19 @@ namespace LDH_UI
 
         public async UniTask<T> ShowPopupUI<T>(T popup) where T : UI_Popup
         {
+            
+            if (_isClosingAllPopups)
+            {
+                Debug.LogWarning("[UIManager] blocked: CloseAll in progress");
+                return null;
+            }
+            
             // 정렬 순서 부여
             SetCanvas(popup.gameObject, Define_LDH.UILayer.Popup, sort: true);
 
             // 최상단으로 Push
             _popupStack.Push(popup);
+            
 
             await popup.ShowAsync();
             return popup;
@@ -260,22 +274,46 @@ namespace LDH_UI
         /// </summary>
         public async UniTask ClosePopupUI(UI_Popup popup, bool destory = true)
         {
+            if (!popup) return;
+            
+            //최상단 보장
             if (_popupStack.Count == 0 || _popupStack.Peek() != popup)
             {
-                Debug.LogWarning($"[{GetType().Name}] 닫으려는 팝업이 최상단 팝업이 아닙니다.");
+                Debug.LogWarning($"[{GetType().Name}] 닫으려는 팝업이 최상단 팝업이 아닙니다.!!!!!");
                 return;
             }
-
-            await popup.CloseAsync();
-
+            
+            // 재진입 방지
+            if (!_closing.Add(popup)) return;
+            
+            
+            // 1) 스택에서 팝부터 하기
             _popupStack.Pop();
             _orderPopup = Mathf.Max(baseOrderPopup, _orderPopup - 1);
-
-            if (destory)
+            
+            //2) 닫기
+            try
             {
-                popup.OnCloseRequested -= HandleCloseRequested;
-                if (popup) Destroy(popup.gameObject);
+                Debug.Log($"{popup.name} 닫기 호출 (pop-first)");
+                await popup.CloseAsync(); // 애니메이션(비동기) 대기
             }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+            }
+            finally
+            {
+                _closing.Remove(popup);
+
+                if (destory)
+                {
+                    popup.OnCloseRequested -= HandleCloseRequested;
+                    if (popup) Destroy(popup.gameObject);
+                    Debug.Log($"[UIManager] after-close: count={_popupStack.Count}, nextTop={(_popupStack.Count>0 ? _popupStack.Peek().name : "none")}");
+                }
+            }
+
+        
 
         }
 
@@ -290,6 +328,7 @@ namespace LDH_UI
 
             // 최상단 팝업 Pop 후 제거
             UI_Popup top = _popupStack.Peek();
+            Debug.Log($"top : {top.name}");
             await ClosePopupUI(top, destroy);
         }
 
@@ -298,10 +337,33 @@ namespace LDH_UI
         /// </summary>
         public async UniTask CloseAllPopupUI()
         {
-            while (_popupStack.Count > 0)
-                await CloseTopPopupUI(true);
+            if (_isClosingAllPopups) return;
+            _isClosingAllPopups = true;
 
-            _orderPopup = baseOrderPopup;
+            Debug.Log(_popupStack.Count +"개의 팝업을 닫습니다.");
+
+            try
+            {
+                while (_popupStack.Count > 0)
+                {
+                    Debug.Log(_popupStack.Count +"개의 팝업을 닫습니다.");
+                    await CloseTopPopupUI(true);
+                }
+              
+                _orderPopup = baseOrderPopup;
+            
+                Debug.Log(_popupStack.Count +"모든 팝업을 닫았습니다.");
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                throw;
+            }
+            finally
+            {
+                _isClosingAllPopups = false;
+            }
+            
         }
 
         

--- a/Assets/LDH/LDH_Scripts/UI/UIManager.cs
+++ b/Assets/LDH/LDH_Scripts/UI/UIManager.cs
@@ -42,11 +42,6 @@ namespace LDH_UI
         [SerializeField] private string popupFolder = "Prefabs/UI/Popup";
         [SerializeField] private string toastFolder = "Prefabs/UI/Toast";
         
-        
-        //---- flag ------ //
-        private bool _isClosingAllPopups;
-
-
         protected override void OnAwake() => Init();
 
         // UI 매니저 초기화
@@ -252,12 +247,6 @@ namespace LDH_UI
         public async UniTask<T> ShowPopupUI<T>(T popup) where T : UI_Popup
         {
             
-            if (_isClosingAllPopups)
-            {
-                Debug.LogWarning("[UIManager] blocked: CloseAll in progress");
-                return null;
-            }
-            
             // 정렬 순서 부여
             SetCanvas(popup.gameObject, Define_LDH.UILayer.Popup, sort: true);
 
@@ -337,8 +326,6 @@ namespace LDH_UI
         /// </summary>
         public async UniTask CloseAllPopupUI()
         {
-            if (_isClosingAllPopups) return;
-            _isClosingAllPopups = true;
 
             Debug.Log(_popupStack.Count +"개의 팝업을 닫습니다.");
 
@@ -358,10 +345,6 @@ namespace LDH_UI
             {
                 Console.WriteLine(e);
                 throw;
-            }
-            finally
-            {
-                _isClosingAllPopups = false;
             }
             
         }

--- a/Assets/LDH/LDH_Scripts/UI/UI_Base.cs
+++ b/Assets/LDH/LDH_Scripts/UI/UI_Base.cs
@@ -120,8 +120,6 @@ namespace LDH_UI
                 if (visible)
                 {
                     if (gameObject!=null && !gameObject.activeSelf) gameObject.SetActive(true);
-                        gameObject.SetActive(true);
-                    
                     
                     // 레이아웃 강제 갱신을 위해 추가
                     await ForceReBuildLayout(transform, ct);
@@ -152,6 +150,8 @@ namespace LDH_UI
                 
               
                 _isAnimating = false;
+                
+
             }
             
 

--- a/Assets/Resources/Prefabs/UI/Popup/UI_Popup_QuitGame.prefab
+++ b/Assets/Resources/Prefabs/UI/Popup/UI_Popup_QuitGame.prefab
@@ -1,0 +1,564 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2918752722868241943
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7101762752501801646}
+  - component: {fileID: 2209969257257515560}
+  - component: {fileID: 719129107487077023}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7101762752501801646
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2918752722868241943}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3638793826310484055}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2209969257257515560
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2918752722868241943}
+  m_CullTransparentMesh: 1
+--- !u!114 &719129107487077023
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2918752722868241943}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3611146815421591028
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 268386715603482473}
+  - component: {fileID: 7334178263929105925}
+  - component: {fileID: 1411550873741388526}
+  m_Layer: 5
+  m_Name: pop up panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &268386715603482473
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3611146815421591028}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3704763664964846197}
+  - {fileID: 5624954358833760973}
+  m_Father: {fileID: 3638793826310484055}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -100, y: 600}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7334178263929105925
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3611146815421591028}
+  m_CullTransparentMesh: 1
+--- !u!114 &1411550873741388526
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3611146815421591028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5283019, g: 0.5283019, b: 0.5283019, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6895393421564462269
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3704763664964846197}
+  - component: {fileID: 7402616818762780416}
+  - component: {fileID: 6778571839296499761}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3704763664964846197
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6895393421564462269}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 268386715603482473}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 100}
+  m_SizeDelta: {x: -100, y: -200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7402616818762780416
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6895393421564462269}
+  m_CullTransparentMesh: 1
+--- !u!114 &6778571839296499761
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6895393421564462269}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "All other players have left. \nReturning to the lobby."
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 50
+  m_fontSizeBase: 50
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &7484297908237063218
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3638793826310484055}
+  - component: {fileID: 4594366881184854360}
+  - component: {fileID: 7952020765489273109}
+  - component: {fileID: 119438005129213991}
+  - component: {fileID: 3414665095031127105}
+  - component: {fileID: 8341945572358257345}
+  m_Layer: 5
+  m_Name: UI_Popup_QuitGame
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3638793826310484055
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7484297908237063218}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7101762752501801646}
+  - {fileID: 268386715603482473}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &4594366881184854360
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7484297908237063218}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &7952020765489273109
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7484297908237063218}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!114 &119438005129213991
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7484297908237063218}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &3414665095031127105
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7484297908237063218}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ebccc9ce335743cf9e5b98505b235fd1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _area: 3
+  cg: {fileID: 8341945572358257345}
+  interactable: 1
+  blocksRaycasts: 1
+  fadeTime: 0.1
+  okButton: {fileID: 5854359914405354430}
+--- !u!225 &8341945572358257345
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7484297908237063218}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!1001 &3769831696203946977
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 268386715603482473}
+    m_Modifications:
+    - target: {fileID: 1330773126853593739, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_Name
+      value: 10_Button_Rect
+      objectReference: {fileID: 0}
+    - target: {fileID: 3364167739469575018, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_text
+      value: OK
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 229
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 112
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 69
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 781e76cf87ee34622a365677a99e99ea, type: 3}
+--- !u!224 &5624954358833760973 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8817762041393369388, guid: 781e76cf87ee34622a365677a99e99ea,
+    type: 3}
+  m_PrefabInstance: {fileID: 3769831696203946977}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &5854359914405354430 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7309338515615268959, guid: 781e76cf87ee34622a365677a99e99ea,
+    type: 3}
+  m_PrefabInstance: {fileID: 3769831696203946977}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Resources/Prefabs/UI/Popup/UI_Popup_QuitGame.prefab.meta
+++ b/Assets/Resources/Prefabs/UI/Popup/UI_Popup_QuitGame.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 20794a43d294f4817a1f69e303264e2e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Prefabs/UI/Popup/UI_Popup_ReadyPanel.prefab
+++ b/Assets/Resources/Prefabs/UI/Popup/UI_Popup_ReadyPanel.prefab
@@ -428,7 +428,7 @@ PrefabInstance:
     - target: {fileID: 232244992926323176, guid: 82ce834bbee0c4d4eaf1a9fde17f8fe9,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 42.5
       objectReference: {fileID: 0}
     - target: {fileID: 232244992926323176, guid: 82ce834bbee0c4d4eaf1a9fde17f8fe9,
         type: 3}
@@ -748,7 +748,7 @@ PrefabInstance:
     - target: {fileID: 6233854001259729811, guid: 82ce834bbee0c4d4eaf1a9fde17f8fe9,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 42.5
       objectReference: {fileID: 0}
     - target: {fileID: 6233854001259729811, guid: 82ce834bbee0c4d4eaf1a9fde17f8fe9,
         type: 3}
@@ -773,7 +773,7 @@ PrefabInstance:
     - target: {fileID: 6385488741782460125, guid: 82ce834bbee0c4d4eaf1a9fde17f8fe9,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 42.5
       objectReference: {fileID: 0}
     - target: {fileID: 6385488741782460125, guid: 82ce834bbee0c4d4eaf1a9fde17f8fe9,
         type: 3}
@@ -903,7 +903,7 @@ PrefabInstance:
     - target: {fileID: 8314953192513217616, guid: 82ce834bbee0c4d4eaf1a9fde17f8fe9,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 42.5
       objectReference: {fileID: 0}
     - target: {fileID: 8314953192513217616, guid: 82ce834bbee0c4d4eaf1a9fde17f8fe9,
         type: 3}


### PR DESCRIPTION
# 🧑‍💻 PR

## 🔗 관련 이슈
- resolves : #39, #42, #44
<!--
- Resolves: #25 => PR 머지 시 해당 이슈 자동 닫힘
- Related to: #25 => 단순 연결, 자동 닫힘 없음
-->

## 💻 버그 해결방법 (Fix 전용)

### 🔧 수정된 버그
<!--
예) 아이템 호버링, 사운드 누락
-->

1. 매칭 취소 직후 빠르게 다시 매칭을 시도할 경우:
- 매칭 버튼이 비활성화된 상태로 고정되고
- 매칭 UI가 표시되지 않으며
- 매칭 로직도 진행되지 않아 화면이 freeze 된 것처럼 보이는 문제
2. Ready 패널이 미니게임 Additive 로드 이후에도 잔존하는 문제
3. 미니게임으로 바뀔 때 ready 패널이 깜박이는 현상

### 💡 해결방법
1. 매칭 버튼 활성화 시점 조정
- 예상 원인 : 매칭 취소 시 버튼이 즉시 활성화되면서, 서버 연결이나 로비 진입이 완료되지 않은 상태에서도 사용자가 다시 누를 수 있었음. 이 경우 버튼은 매칭 시작으로 판단해 비활성화되지만, 실제 매칭 로직은 실행 조건을 충족하지 않아 freeze 상태처럼 보였음.
- 해결 : 버튼 활성화 조건을 Photon 상태(ClientState) 기반으로 관리하여, 실제 매칭 가능 상태일 때만 활성화되도록 변경. `PhotonNetwork.NetworkingClient.StateChanged` 이벤트를 구독하여 상태 변화마다 버튼을 갱신.

```csharp
private void Subscribe()
{
    PhotonNetwork.NetworkingClient.StateChanged += OnPhotonStateChanged;
}

private void Unsubscribe()
{
    PhotonNetwork.NetworkingClient.StateChanged -= OnPhotonStateChanged;

}


 #region Matching Button Control

  private void OnPhotonStateChanged(ClientState prev, ClientState curr)
  {
      RefreshButtons();
  }   


  private bool ReadyToMatch() =>
      PhotonNetwork.IsConnected && PhotonNetwork.InLobby && !PhotonNetwork.InRoom && !IsMatching;

  private void RefreshButtons()
  {
      bool ready = ReadyToMatch();
      
      //Debug.Log($"[MatchController] isconnected :{PhotonNetwork.IsConnected} / inlobby : {PhotonNetwork.InLobby} / inroom : {PhotonNetwork.InRoom} / is maching : {IsMatching} ");
      QuickMatch?.SetButtonInteractable(ready);
      PrivateMatch?.SetButtonInteractable(ready);
  }

  #endregion
```

2. ready 패널 닫는 타이밍 수정
- 예상 원인 : 기존에는 미니게임 씬을 로드한 이후 Ready 패널 닫기를 호출했음.
이 경우 새로운 팝업이 최상단에 올라오면 Ready 패널이 닫히지 않을 수 있었고, 또한 닫기 로직이 fire-and-forget 비동기로 처리되어 닫힘 완료를 보장하지 못했음.
- 해결 : 씬 로드 이전에 Ready 패널을 닫고, 닫힘 완료까지 대기한 뒤 Additive 로드를 진행하도록 변경. UI 로직(UniTask)과 메인 로직(코루틴)의 혼합 문제는 `ToCoroutine()`을 사용해 해결.

```csharp
public IEnumerator Co_LoadingMini(Action onLoadingMiniGame = null)
{
    
    
    if (_currentMini == null)
    {
        if (_isMaster())
            _pc.SetRoomProps(RoomProps.State, MainState.Picking.ToString());
        yield break;
    }

    yield return _uiBinder.CloseReadyPanel().ToCoroutine();
    
    // Additive Load
    yield return MiniGameLoader.LoadAdditive(_sceneName(_currentMini), null);
  
    if (_isMaster())
        _pc.SetRoomProps(RoomProps.State, MainState.PlayingMiniGame.ToString());
    
    onLoadingMiniGame?.Invoke();
    
}
```


3. 카메라 비활성과 씬 전환 순서 수정 (Ready 패널 깜빡임 방지)
- 예상 원인 : 기존에는 Addtive로 미니게임 씬을 로드하기 직전에 메인 맵의 카메라를 비활성화 함. 그 후 씬을 올림. 이에 따라 씬이 올라오기 전까지 활성화된 카메라가 없는 프레임이 생겨 UI가 깜박이는 것으로 추정
- 해결 : Additive 로드가 완료된 후에 메인 맵 카메라/오디오/이벤트시스템을 비활성화하도록 순서 변경하여 해결
```csharp
public static IEnumerator LoadAdditive(string sceneName, Action onReady)
{
    // 메인 씬 컴포넌트 중 비활성화 후보 수집
    var mainScene = SceneManager.GetActiveScene();
    _disabledOnMain.Clear();
    // 이전: 여기서 Disable<Camera/AudioListener/EventSystem>() 호출 (❌)

    var op = SceneManager.LoadSceneAsync(sceneName, LoadSceneMode.Additive);
    while (!op.isDone) yield return null;

    _loadedMiniScene = SceneManager.GetSceneByName(sceneName);
    _hasMiniScene = _loadedMiniScene.IsValid();

    // 이후: Additive 로드 완료된 시점에서 비활성화 처리 (✅)
    Disable<Camera>(mainScene);
    Disable<AudioListener>(mainScene);
    Disable<EventSystem>(mainScene); 

    if (_hasMiniScene)
    {
        Debug.Log("미니게임 씬 활성화 시점");
        SceneManager.SetActiveScene(_loadedMiniScene);
    }

    onReady?.Invoke();
}

```

### ✔️ 버그 체크리스트
- [ ] 추가로 수정이 필요함
- [x] 수정 완료
- [ ] QA 테스트 통과

### 💬 기타 사항
<!--
예) 아이템 중복 버그 → 수정 중 (RPC 권한 마스터로 위임으로 수정 중)
-->

## ✅ PR 체크리스트
- [ ] 빌드 오류 없음
- [x] 기능 정상 작동 확인
- [x] 커밋 메시지 규칙 준수
- [x] Scene 충돌 없음

## 💬 기타 사항
