### PR TITLE
[Refactor] Room Object를 사용한 미니게임은 코디네이터가 작동하지 않도록 설정 & [Refactor] 젠가 게임 데이터 및 이벤트 정리 로직 추가

### DIFF
--- a/Assets/LDH/LDH_Scripts/Network/PhotonViewSync.cs
+++ b/Assets/LDH/LDH_Scripts/Network/PhotonViewSync.cs
@@ -52,7 +52,18 @@ namespace LDH_MainGame
         public IEnumerator SafePhotonViewSync(PhotonViewCoordinator coordinator)
         {
             _coordinator = coordinator;
-            //0단계 : 코디네이터 캐싱 완료
+
+            // 0단계 : 포톤뷰 조정이 필요한지 체크 (여기서 조기 종료)
+            if (_coordinator == null || _coordinator.GetSceneViews() == null || _coordinator.GetSceneViews().Length == 0)
+            {
+                Debug.Log("[PhotonViewSync] 조정할 포톤 뷰가 없습니다. (skip coordination)");
+                _syncCompleted = true;     // BaseGameSceneController가 기다리는 플래그 만족
+                _coordinator = null;
+                Debug.Log("=== SafePhotonViewSync Completed (skipped) ===");
+                yield break;
+            }
+
+            // 0.5단계 : 코디네이터 캐싱 완료
             photonView.RPC(nameof(RPC_HasCoordination), RpcTarget.All,
                 PhotonNetwork.LocalPlayer.ActorNumber);
             

--- a/Assets/LTH/LTH_Scripts/Cameras/JengaCollapseUICam.cs
+++ b/Assets/LTH/LTH_Scripts/Cameras/JengaCollapseUICam.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+public class JengaCollapseUICam : MonoBehaviour
+{
+    [Header("Camera / RT")]
+    [SerializeField] private Camera cam;
+    [SerializeField] private RenderTexture targetRT;
+    [SerializeField] private Vector2Int rtSize = new(1024, 1024);
+
+    [Header("Framing")]
+    [SerializeField] private Vector3 offset = new(0f, 2.2f, -3.0f);
+    [SerializeField] private float fov = 40f;
+    [SerializeField] private float lookUpOffset = 0.3f;   // 살짝 위를 보게
+
+    void Reset() => EnsureDefaults();
+    void Awake() => EnsureDefaults();
+
+    private void EnsureDefaults()
+    {
+        if (!cam) cam = GetComponent<Camera>();
+        if (!cam) cam = gameObject.AddComponent<Camera>();
+
+        // 카메라 기본 세팅(빌트인/URP 공용)
+        cam.enabled = false;
+        cam.clearFlags = CameraClearFlags.SolidColor;
+        cam.backgroundColor = new Color(0, 0, 0, 0); // 투명
+        cam.allowHDR = false;
+        cam.allowMSAA = false;
+        cam.fieldOfView = fov;
+
+        // RT 보정
+        if (!targetRT || targetRT.width != rtSize.x || targetRT.height != rtSize.y)
+        {
+            if (targetRT) targetRT.Release();
+            targetRT = new RenderTexture(rtSize.x, rtSize.y, 16, RenderTextureFormat.ARGB32)
+            {
+                useMipMap = false,
+                autoGenerateMips = false,
+                antiAliasing = 1
+            };
+            targetRT.Create();
+        }
+    }
+
+    /// <summary>
+    /// 한 프레임 켰다가 끄는 방식으로 캡처
+    /// settleDelay: 붕괴 애니가 끝난 뒤 살짝 기다렸다가 찍고 싶을 때(예: 0.05 ~ 0.2)
+    /// </summary>
+    public IEnumerator CaptureCo(GameObject towerRoot, LayerMask arenaMask, float settleDelay, Action<RenderTexture> onDone)
+    {
+        if (settleDelay > 0f) yield return new WaitForSeconds(settleDelay);
+
+        if (!PrepareFraming(towerRoot, arenaMask))
+        {
+            onDone?.Invoke(null);
+            yield break;
+        }
+
+        var prev = cam.targetTexture;
+        cam.targetTexture = targetRT;
+
+        // SRP/URP에서도 확실히 그 프레임에 렌더되도록
+        cam.enabled = true;
+        // 렌더 큐에 올라가도록 프레임 끝까지 대기
+        yield return new WaitForEndOfFrame();
+        cam.enabled = false;
+
+        cam.targetTexture = prev;
+        onDone?.Invoke(targetRT);
+    }
+
+    private bool PrepareFraming(GameObject towerRoot, LayerMask arenaMask)
+    {
+        if (!cam || !towerRoot) return false;
+
+        // 내 아레나만 찍기
+        cam.cullingMask = arenaMask;
+
+        // 타워 바운딩 계산
+        var rends = towerRoot.GetComponentsInChildren<Renderer>(includeInactive: true);
+        if (rends == null || rends.Length == 0) return false;
+
+        var b = new Bounds(rends[0].bounds.center, Vector3.zero);
+        for (int i = 1; i < rends.Length; i++) b.Encapsulate(rends[i].bounds);
+
+        var look = b.center + Vector3.up * lookUpOffset;
+
+        // 좌표 배치
+        cam.transform.position = look + offset;
+        cam.transform.LookAt(look);
+        cam.fieldOfView = fov;
+
+        // RT 사이즈 보증
+        if (!targetRT || !targetRT.IsCreated())
+        {
+            EnsureDefaults();
+        }
+        return true;
+    }
+
+    public static bool IsSRPActive() => GraphicsSettings.currentRenderPipeline != null;
+}

--- a/Assets/LTH/LTH_Scripts/Cameras/JengaCollapseUICam.cs.meta
+++ b/Assets/LTH/LTH_Scripts/Cameras/JengaCollapseUICam.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94a1a611ffc92aa47a85fe13856c093e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaGameManager/JengaGameManager.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaGameManager/JengaGameManager.cs
@@ -594,4 +594,50 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
         // OnTowerCollapsed의 종료 조건 판단에 사용함
         return players.Count(kv => kv.Value.isAlive);
     }
+
+
+    #region 강제 정리 (플레이어 1명이라도 이탈 시 호출)
+
+    protected override void OnDestroy()
+    {
+        Debug.Log("[JengaGameManager] OnDestroy - cleaning up resources");
+
+        // 1. 이벤트 해제 (메모리 누수 방지)
+        OnTimeUpdated = null;
+        OnGameStateChanged = null;
+        OnPlayerAction = null;
+        OnPlayerFinished = null;
+        OnGameFinished = null;
+
+        // 2. 전역 플레이어 데이터에서 젠가 관련 데이터만 정리
+        if (PlayerManager.Instance != null)
+        {
+            foreach (var player in PlayerManager.Instance.Players.Values)
+            {
+                if (player != null)
+                {
+                    player.JengaData = null;
+                    player.WinThisMiniGame = false;
+                }
+            }
+        }
+
+        // 3. 룸 프로퍼티에서 젠가 관련 데이터 제거 (다음 게임을 위해)
+        if (PhotonNetwork.InRoom)
+        {
+            var clearProps = new Hashtable
+            {
+                { JengaRoomProps.KEY_STATE, null },
+                { JengaRoomProps.KEY_START_TIME, null },
+                { JengaRoomProps.KEY_DURATION, null },
+                { JengaRoomProps.KEY_RANK_UIDS, null },
+                { JengaRoomProps.KEY_RANK_VALS, null }
+            };
+            PhotonNetwork.CurrentRoom.SetCustomProperties(clearProps);
+        }
+
+        base.OnDestroy();
+    }
+
+    #endregion
 }

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaGameManager/JengaGameManager.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaGameManager/JengaGameManager.cs
@@ -93,6 +93,7 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
         }
     }
 
+
     #region 플레이어 초기화
     private void InitializePlayers()
     {
@@ -138,6 +139,7 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
         }
         Debug.Log($"[JengaGameManager - InitializePlayers] Initialized {players.Count} players");
     }
+
     #endregion
 
     public void StartGame()
@@ -347,9 +349,18 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
     /// </summary>
     private void EndGame()
     {
-        JengaNetworkManager.Instance.BroadcastGameState(JengaGameState.Finished); // 게임 상태를 "Finished"로 변경
+        // 1) 타이머 0으로 고정 & 즉시 UI 반영
+        remainingTime = 0f;
+        OnTimeUpdated?.Invoke(remainingTime);
 
-        // 순위 계산 (점수 기준, 완료 시간도 고려)
+        // 2) 상태 전환 (ApplyGameStateChange 내부에서 KEY_STATE를 룸 프로퍼티로 기록)
+        ApplyGameStateChange(JengaGameState.Finished);
+
+        // 3) 네트워크로 상태 브로드캐스트 (RPC)
+        JengaNetworkManager.Instance.BroadcastGameState(JengaGameState.Finished); // 게임 상태를 "Finished"로 변경
+        JengaNetworkManager.Instance.BroadcastTimeSync(0f); // 전 클라 타이머 0 표시
+
+        // 4) 순위 계산 & UI/룸프로퍼티 반영(랭킹만 기록; KEY_STATE는 위에서 이미 기록됨)
         var rankings = CalculateRankings();
         OnGameFinished?.Invoke(rankings); // OnGameFinished로 외부에 알림
 
@@ -363,12 +374,11 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
         {
             { JengaRoomProps.KEY_RANK_UIDS, uids },
             { JengaRoomProps.KEY_RANK_VALS, rks  },
-            { JengaRoomProps.KEY_STATE,     (byte)JengaGameState.Finished }
         };
             PhotonNetwork.CurrentRoom.SetCustomProperties(props);
         }
 
-        // 메인 게임에 결과 전달
+        // 5) 메인 게임에 결과 전달
         SendResultToMainGame(rankings);
     }
 

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaNetwork/JengaNetworkManager.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaNetwork/JengaNetworkManager.cs
@@ -679,4 +679,31 @@ public class JengaNetworkManager : PunSingleton<JengaNetworkManager>, IGameCompo
     }
 
     #endregion
+
+    #region 강제 정리 (플레이어 1명이라도 이탈 시 호출)
+
+    protected override void OnDestroy()
+    {
+        Debug.Log("[JengaNetworkManager] OnDestroy - cleaning up resources");
+
+        // 실행 중인 코루틴들 정리
+        if (_pendingApplyCo != null)
+        {
+            StopCoroutine(_pendingApplyCo);
+            _pendingApplyCo = null;
+        }
+
+        if (_countdownFailsafeCo != null)
+        {
+            StopCoroutine(_countdownFailsafeCo);
+            _countdownFailsafeCo = null;
+        }
+
+        // 입력 락 해제
+        ReleaseCountdownLock();
+
+        base.OnDestroy();
+    }
+
+    #endregion
 }

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaNetwork/JengaNetworkManager.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaNetwork/JengaNetworkManager.cs
@@ -679,31 +679,4 @@ public class JengaNetworkManager : PunSingleton<JengaNetworkManager>, IGameCompo
     }
 
     #endregion
-
-    #region 강제 정리 (플레이어 1명이라도 이탈 시 호출)
-
-    protected override void OnDestroy()
-    {
-        Debug.Log("[JengaNetworkManager] OnDestroy - cleaning up resources");
-
-        // 실행 중인 코루틴들 정리
-        if (_pendingApplyCo != null)
-        {
-            StopCoroutine(_pendingApplyCo);
-            _pendingApplyCo = null;
-        }
-
-        if (_countdownFailsafeCo != null)
-        {
-            StopCoroutine(_countdownFailsafeCo);
-            _countdownFailsafeCo = null;
-        }
-
-        // 입력 락 해제
-        ReleaseCountdownLock();
-
-        base.OnDestroy();
-    }
-
-    #endregion
 }

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaTimingManager/JengaTimingManager.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaTimingManager/JengaTimingManager.cs
@@ -224,6 +224,26 @@ namespace MiniGameJenga
             ResetTimingState();
         }
 
+        #region 강제 정리 (플레이어 1명이라도 이탈 시 호출)
+        protected override void OnDestroy()
+        {
+            Debug.Log("[JengaTimingManager] OnDestroy - cleaning up resources");
+
+            // 진행 중인 타이밍 게임 취소
+            if (_isTimingActive)
+            {
+                CancelTiming();
+            }
+
+            // 이벤트 구독 해제 (OnDisable에서도 하지만 안전장치)
+            JengaBlock.OnAnyBlockTimingStart -= HandleTimingStart;
+            UnsubscribeFromTimingUI();
+
+            base.OnDestroy();
+        }
+        #endregion
+
+
 #if UNITY_EDITOR
         /// <summary>
         /// 에디터에서 TimingUI 수동 설정용 (Inspector에서 드래그&드롭)

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaTower/JengaTowerManager.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaTower/JengaTowerManager.cs
@@ -188,35 +188,6 @@ public class JengaTowerManager : CombinedSingleton<JengaTowerManager>, IGameComp
         PhotonNetwork.AddCallbackTarget(this);
     }
 
-    private void OnDisable()
-    {
-        if (JengaGameManager.Instance != null)
-            JengaGameManager.Instance.OnGameStateChanged -= HandleStateChanged;
-
-        foreach (var kv in _towerMuteHandlers)
-        {
-            var actor = kv.Key;
-            var pair = kv.Value;
-            var tower = GetPlayerTower(actor);
-            if (tower != null)
-            {
-                if (pair.on != null) tower.CollapseStarted -= pair.on;
-                if (pair.off != null) tower.CollapseFinished -= pair.off;
-            }
-        }
-        _towerMuteHandlers.Clear();
-
-        ReleaseCollapseLockNow();
-        _mutedActors.Clear();
-
-        PhotonNetwork.RemoveCallbackTarget(this);
-
-        if (PhotonNetwork.InRoom && PhotonNetwork.IsMasterClient)
-        {
-            CleanupAllProxies();
-        }
-    }
-
     private void HandleStateChanged(JengaGameState state)
     {
         if (state == JengaGameState.Finished)
@@ -697,6 +668,52 @@ public class JengaTowerManager : CombinedSingleton<JengaTowerManager>, IGameComp
 
     // 플레이어 프로퍼티 변경 (uid 등)
     public void OnPlayerPropertiesUpdate(Player targetPlayer, Hashtable changedProps) { }
+
+    #endregion
+
+    #region 강제 정리 (플레이어 1명이라도 이탈 시 호출)
+    protected override void OnDestroy()
+    {
+        Debug.Log("[JengaTowerManager] OnDestroy - cleaning up resources");
+
+        // 게임 매니저 이벤트 해제
+        if (JengaGameManager.Instance != null)
+            JengaGameManager.Instance.OnGameStateChanged -= HandleStateChanged;
+
+        // 타워별 이벤트 핸들러 정리
+        foreach (var kv in _towerMuteHandlers)
+        {
+            var actor = kv.Key;
+            var pair = kv.Value;
+            var tower = GetPlayerTower(actor);
+            if (tower != null)
+            {
+                if (pair.on != null) tower.CollapseStarted -= pair.on;
+                if (pair.off != null) tower.CollapseFinished -= pair.off;
+            }
+        }
+        _towerMuteHandlers.Clear();
+
+        // 입력 락 해제 및 상태 정리
+        ReleaseCollapseLockNow();
+        _mutedActors.Clear();
+
+        // Photon 콜백 해제
+        PhotonNetwork.RemoveCallbackTarget(this);
+
+        // 마스터라면 프록시 정리
+        if (PhotonNetwork.InRoom && PhotonNetwork.IsMasterClient)
+        {
+            CleanupAllProxies();
+        }
+
+        base.OnDestroy();
+    }
+
+    private void OnDisable()
+    {
+        PhotonNetwork.RemoveCallbackTarget(this);
+    }
 
     #endregion
 

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaTower/JengaTowerManager.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaTower/JengaTowerManager.cs
@@ -221,11 +221,36 @@ public class JengaTowerManager : CombinedSingleton<JengaTowerManager>, IGameComp
         Action on = () => { 
             MuteArena(actorNumber, true); 
             SetTowerInputEnabled(actorNumber, false);
-
             if (actorNumber == PhotonNetwork.LocalPlayer.ActorNumber)
+            {
                 JengaUIManager.Instance.HideRotateButton();
+            }
         };
-        Action off = () => { MuteArena(actorNumber, false); SetTowerInputEnabled(actorNumber, true); };
+
+        Action off = () => { 
+            MuteArena(actorNumber, false); 
+            SetTowerInputEnabled(actorNumber, true);
+
+            // 로컬 플레이어가 무너졌다면: 스냅샷 찍고 '대기중' UI
+            if (actorNumber == PhotonNetwork.LocalPlayer.ActorNumber)
+            {
+                var snapper = FindFirstObjectByType<JengaCollapseUICam>(FindObjectsInactive.Include);
+                if (snapper)
+                {
+                    var mask = GetArenaLayerMaskByActor(actorNumber);
+                    // 붕괴 연출이 살짝 정리되도록 0.05 ~ 0.2초 기다렸다 촬영
+                    StartCoroutine(snapper.CaptureCo(tower.gameObject, mask, 0.08f, tex =>
+                    {
+                        JengaUIManager.Instance?.ShowWaiting(tex);
+                    }));
+                }
+                else
+                {
+                    // 스냅샷 장치가 없으면 미리보기 없이 대기만
+                    JengaUIManager.Instance?.ShowWaiting(null);
+                }
+            }
+        };
         tower.CollapseStarted += on;
         tower.CollapseFinished += off;
         _towerMuteHandlers[actorNumber] = (on, off);
@@ -593,11 +618,11 @@ public class JengaTowerManager : CombinedSingleton<JengaTowerManager>, IGameComp
         var tower = GetPlayerTower(ownerActorNumber);
         if (tower == null) return;
 
-        foreach (var b in tower.allBlocks)
-        {
-            if (b && b.TryGetComponent<Collider>(out var col))
-                col.enabled = enabled;
-        }
+        //foreach (var b in tower.allBlocks)
+        //{
+        //    if (b && b.TryGetComponent<Collider>(out var col))
+        //        col.enabled = enabled;
+        //}
     }
 
     #endregion

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaUIManager/JengaUIManager.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaUIManager/JengaUIManager.cs
@@ -262,15 +262,20 @@ public class JengaUIManager : CombinedSingleton<JengaUIManager>, IGameComponent
 
     #endregion
 
+    #region 강제 정리 (플레이어 1명이라도 이탈 시 호출)
     protected override void OnDestroy()
     {
+        Debug.Log("[JengaUIManager] OnDestroy - cleaning up resources");
+
         // 메모리 누수 방지를 위한 이벤트 구독 해제
         if (JengaGameManager.Instance != null)
         {
             JengaGameManager.Instance.OnTimeUpdated -= UpdateTimerUI;
             JengaGameManager.Instance.OnGameStateChanged -= OnGameStateChanged;
+            JengaGameManager.Instance.OnGameFinished -= OnGameFinished_ShowRanking;
         }
         base.OnDestroy();
     }
+    #endregion
 
 }

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaUIManager/JengaUIManager.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaUIManager/JengaUIManager.cs
@@ -5,6 +5,7 @@ using Photon.Pun;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using InputBlocker;
 
 public class JengaUIManager : CombinedSingleton<JengaUIManager>, IGameComponent
 {
@@ -20,6 +21,13 @@ public class JengaUIManager : CombinedSingleton<JengaUIManager>, IGameComponent
 
     [Header("회전 버튼")]
     [SerializeField] private Button rotateButton;
+
+    [Header("대기 UI")]
+    [SerializeField] private GameObject waitingPanel;
+    [SerializeField] private RawImage waitingPreview; // 선택: 없으면 null 유지
+    private bool _iAmEliminated = false;
+    private InputLockToken _eliminateLock;
+
 
     protected override void OnAwake()
     {
@@ -64,10 +72,17 @@ public class JengaUIManager : CombinedSingleton<JengaUIManager>, IGameComponent
                 // 게임 시작 시 카운트다운 UI 숨김 (혹시 남아있을 경우를 대비)
                 HideCountdown();
                 if (rankingUI != null) rankingUI.Hide();
+
+                _iAmEliminated = false;
+                if (waitingPanel) waitingPanel.SetActive(false);
+
+                _eliminateLock?.Dispose();
+                _eliminateLock = null;
                 break;
 
             case JengaGameState.Finished:
-                // 게임 종료 시 처리
+                // 게임 종료 시 00:00
+                if (timerText != null) timerText.text = "00:00";
                 break;
         }
     }
@@ -106,6 +121,12 @@ public class JengaUIManager : CombinedSingleton<JengaUIManager>, IGameComponent
         {
             rotateButton.gameObject.SetActive(false);
         }
+
+        if (waitingPanel)
+        {
+            waitingPanel.SetActive(false);
+        }
+        _iAmEliminated = false;
     }
     #endregion
 
@@ -262,6 +283,24 @@ public class JengaUIManager : CombinedSingleton<JengaUIManager>, IGameComponent
 
     #endregion
 
+    #region 대기 UI
+    public void ShowWaiting(RenderTexture rt = null)
+    {
+        _iAmEliminated = true;
+
+        if (waitingPreview && rt) waitingPreview.texture = rt;
+        if (waitingPanel) waitingPanel.SetActive(true);
+
+        if (_eliminateLock == null)
+            _eliminateLock = InputManager.Instance?.Acquire(InputType.Interaction, "Jenga eliminated");
+
+        HideRotateButton(); // 조작 불가
+    }
+
+
+    #endregion
+
+
     #region 강제 정리 (플레이어 1명이라도 이탈 시 호출)
     protected override void OnDestroy()
     {
@@ -274,6 +313,8 @@ public class JengaUIManager : CombinedSingleton<JengaUIManager>, IGameComponent
             JengaGameManager.Instance.OnGameStateChanged -= OnGameStateChanged;
             JengaGameManager.Instance.OnGameFinished -= OnGameFinished_ShowRanking;
         }
+        _eliminateLock?.Dispose();
+        _eliminateLock = null;
         base.OnDestroy();
     }
     #endregion

--- a/Assets/Scenes/MiniGameJengaScene.unity
+++ b/Assets/Scenes/MiniGameJengaScene.unity
@@ -709,6 +709,83 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 124241425}
   m_CullTransparentMesh: 1
+--- !u!1 &132007707
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 132007708}
+  - component: {fileID: 132007710}
+  - component: {fileID: 132007709}
+  m_Layer: 5
+  m_Name: WaitingPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &132007708
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 132007707}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1800503797}
+  - {fileID: 244144262}
+  m_Father: {fileID: 419628864}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 2, y: -408}
+  m_SizeDelta: {x: -323.419, y: -1432.997}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &132007709
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 132007707}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &132007710
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 132007707}
+  m_CullTransparentMesh: 1
 --- !u!1 &132400450
 GameObject:
   m_ObjectHideFlags: 0
@@ -1094,7 +1171,7 @@ PrefabInstance:
     - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 1.0009354
       objectReference: {fileID: 0}
     - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
         type: 3}
@@ -1444,6 +1521,181 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 240145881}
   m_CullTransparentMesh: 1
+--- !u!1 &244144261
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 244144262}
+  - component: {fileID: 244144264}
+  - component: {fileID: 244144263}
+  m_Layer: 5
+  m_Name: WatingText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &244144262
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 244144261}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 132007708}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.0022125, y: 4.988}
+  m_SizeDelta: {x: 756.59, y: 249.523}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &244144263
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 244144261}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uB300\uAE30 \uC911..."
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: b5210d6beb3e9c648ba1879e2bd1dc84, type: 2}
+  m_sharedMaterial: {fileID: -2889749735182874533, guid: b5210d6beb3e9c648ba1879e2bd1dc84,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 100
+  m_fontSizeBase: 100
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &244144264
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 244144261}
+  m_CullTransparentMesh: 1
+--- !u!21 &249672752
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
+    - _WidthHeightRadius: {r: 141.364, g: 45.043, b: 40, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1001 &253332375
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2129,46 +2381,6 @@ MonoBehaviour:
   m_CameraActivatedEvent:
     m_PersistentCalls:
       m_Calls: []
---- !u!21 &331147682
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
-    - _WidthHeightRadius: {r: 141.364, g: 45.043, b: 40, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1001 &341978547
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2553,6 +2765,153 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1.1, y: 1, z: 1.1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &392257174
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 392257178}
+  - component: {fileID: 392257177}
+  - component: {fileID: 392257176}
+  - component: {fileID: 392257175}
+  m_Layer: 0
+  m_Name: CollapseCam
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &392257175
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 392257174}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 94a1a611ffc92aa47a85fe13856c093e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 392257177}
+  targetRT: {fileID: 483322393}
+  rtSize: {x: 512, y: 512}
+  offset: {x: 0, y: 2.2, z: -3}
+  fov: 40
+  lookUpOffset: 0.3
+--- !u!114 &392257176
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 392257174}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+--- !u!20 &392257177
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 392257174}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 40
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 0
+  m_AllowMSAA: 0
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &392257178
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 392257174}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 158.84209, y: 268.27615, z: -28.395874}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &396221719
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2788,7 +3147,7 @@ PrefabInstance:
     - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 1.0009354
       objectReference: {fileID: 0}
     - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
         type: 3}
@@ -2937,6 +3296,10 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 231174370}
+    - targetCorrespondingSourceObject: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 132007708}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b4f2cd633f84448609793082bcf66d70, type: 3}
 --- !u!224 &419628864 stripped
@@ -3139,6 +3502,44 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 482523130}
   m_PrefabAsset: {fileID: 0}
+--- !u!84 &483322393
+RenderTexture:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_ImageContentsHash:
+    serializedVersion: 2
+    Hash: 00000000000000000000000000000000
+  m_ForcedFallbackFormat: 4
+  m_DownscaleFallback: 0
+  m_IsAlphaChannelOptional: 0
+  serializedVersion: 5
+  m_Width: 1024
+  m_Height: 1024
+  m_AntiAliasing: 1
+  m_MipCount: -1
+  m_DepthStencilFormat: 90
+  m_ColorFormat: 4
+  m_MipMap: 0
+  m_GenerateMips: 0
+  m_SRGB: 1
+  m_UseDynamicScale: 0
+  m_BindMS: 0
+  m_EnableCompatibleFormat: 1
+  m_EnableRandomWrite: 0
+  m_TextureSettings:
+    serializedVersion: 2
+    m_FilterMode: 1
+    m_Aniso: 0
+    m_MipBias: 0
+    m_WrapU: 1
+    m_WrapV: 1
+    m_WrapW: 1
+  m_Dimension: 2
+  m_VolumeDepth: 1
+  m_ShadowSamplingMode: 2
 --- !u!1001 &487881567
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4193,46 +4594,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!21 &603768205
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
-    - _WidthHeightRadius: {r: 1275.0493, g: 849.3999, b: 80, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1001 &656484616
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5497,7 +5858,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 331147682}
+  m_Material: {fileID: 249672752}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
@@ -10590,6 +10951,78 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1728579986}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1800503796
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1800503797}
+  - component: {fileID: 1800503799}
+  - component: {fileID: 1800503798}
+  m_Layer: 5
+  m_Name: WaitingPreview
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1800503797
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1800503796}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 132007708}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 4.235014, y: 535.196}
+  m_SizeDelta: {x: 591.326, y: 573.867}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1800503798
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1800503796}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &1800503799
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1800503796}
+  m_CullTransparentMesh: 1
 --- !u!1001 &1804809741
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10971,46 +11404,6 @@ Material:
     - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
     - _WidthHeightRadius: {r: 1192.5742, g: 319.42212, b: 80, a: 0}
   m_BuildTextureStacks: []
---- !u!21 &1931464972
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
-    - _WidthHeightRadius: {r: 1192.5742, g: 319.42212, b: 80, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1 &1932304810
 GameObject:
   m_ObjectHideFlags: 0
@@ -11191,6 +11584,46 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!21 &1957836985
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
+    - _WidthHeightRadius: {r: 1192.5742, g: 319.42212, b: 80, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1001 &1979129519
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11282,6 +11715,46 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1979129519}
   m_PrefabAsset: {fileID: 0}
+--- !u!21 &2010034492
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
+    - _WidthHeightRadius: {r: 1275.0493, g: 849.3999, b: 80, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1001 &2026746948
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -12454,14 +12927,29 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3018064498990676996, guid: 79cc09c142541904797f0026eef5731f,
         type: 3}
+      propertyPath: failPanel
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3018064498990676996, guid: 79cc09c142541904797f0026eef5731f,
+        type: 3}
       propertyPath: timerText
       value: 
       objectReference: {fileID: 29469107}
     - target: {fileID: 3018064498990676996, guid: 79cc09c142541904797f0026eef5731f,
         type: 3}
+      propertyPath: failPreview
+      value: 
+      objectReference: {fileID: 1800503798}
+    - target: {fileID: 3018064498990676996, guid: 79cc09c142541904797f0026eef5731f,
+        type: 3}
       propertyPath: rotateButton
       value: 
       objectReference: {fileID: 231174371}
+    - target: {fileID: 3018064498990676996, guid: 79cc09c142541904797f0026eef5731f,
+        type: 3}
+      propertyPath: waitingPanel
+      value: 
+      objectReference: {fileID: 132007707}
     - target: {fileID: 3018064498990676996, guid: 79cc09c142541904797f0026eef5731f,
         type: 3}
       propertyPath: countdownText
@@ -12472,6 +12960,11 @@ PrefabInstance:
       propertyPath: countdownPanel
       value: 
       objectReference: {fileID: 938219809}
+    - target: {fileID: 3018064498990676996, guid: 79cc09c142541904797f0026eef5731f,
+        type: 3}
+      propertyPath: waitingPreview
+      value: 
+      objectReference: {fileID: 1800503798}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -14039,6 +14532,7 @@ SceneRoots:
   m_Roots:
   - {fileID: 330585546}
   - {fileID: 2139196079}
+  - {fileID: 392257178}
   - {fileID: 410087041}
   - {fileID: 832575519}
   - {fileID: 1551513673}

--- a/Assets/Scenes/MiniGameJengaScene.unity
+++ b/Assets/Scenes/MiniGameJengaScene.unity
@@ -709,46 +709,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 124241425}
   m_CullTransparentMesh: 1
---- !u!21 &128405443
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
-    - _WidthHeightRadius: {r: 141.364, g: 45.043, b: 40, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1 &132400450
 GameObject:
   m_ObjectHideFlags: 0
@@ -1134,7 +1094,7 @@ PrefabInstance:
     - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1.0009443
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
         type: 3}
@@ -2169,6 +2129,46 @@ MonoBehaviour:
   m_CameraActivatedEvent:
     m_PersistentCalls:
       m_Calls: []
+--- !u!21 &331147682
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
+    - _WidthHeightRadius: {r: 141.364, g: 45.043, b: 40, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1001 &341978547
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2788,7 +2788,7 @@ PrefabInstance:
     - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1.0009443
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
         type: 3}
@@ -3959,7 +3959,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &545133230
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3972,12 +3972,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 48c2c32953764648bd684ac38a9d4b47, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  sceneViews:
-  - {fileID: 0}
-  - {fileID: 0}
-  roots:
-  - {fileID: 0}
-  - {fileID: 0}
+  sceneViews: []
+  roots: []
 --- !u!4 &545133231
 Transform:
   m_ObjectHideFlags: 0
@@ -4197,7 +4193,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!21 &646269485
+--- !u!21 &603768205
 Material:
   serializedVersion: 8
   m_ObjectHideFlags: 0
@@ -4235,7 +4231,7 @@ Material:
     - _UseUIAlphaClip: 0
     m_Colors:
     - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
-    - _WidthHeightRadius: {r: 1192.5742, g: 319.42212, b: 80, a: 0}
+    - _WidthHeightRadius: {r: 1275.0493, g: 849.3999, b: 80, a: 0}
   m_BuildTextureStacks: []
 --- !u!1001 &656484616
 PrefabInstance:
@@ -5501,7 +5497,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 128405443}
+  m_Material: {fileID: 331147682}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
@@ -6953,46 +6949,6 @@ Transform:
   - {fileID: 3610911797514433177}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!21 &1286904608
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
-    - _WidthHeightRadius: {r: 1275.0493, g: 849.3999, b: 80, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1001 &1288740885
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10976,6 +10932,46 @@ Transform:
   m_PrefabInstance: {fileID: 1907386681}
   m_PrefabAsset: {fileID: 0}
 --- !u!21 &1910882250
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
+    - _WidthHeightRadius: {r: 1192.5742, g: 319.42212, b: 80, a: 0}
+  m_BuildTextureStacks: []
+--- !u!21 &1931464972
 Material:
   serializedVersion: 8
   m_ObjectHideFlags: 0


### PR DESCRIPTION
# 🧑‍💻 PR

## 🔥 작업 내용 요약
- [Refactor] Room Object를 사용한 미니게임은 코디네이터가 작동하지 않도록 설정
- [Refactor] 젠가 게임 데이터 및 이벤트 정리 로직 추가 
<br>

## 💻 작업 구현 방법 
### 📝 구현 설명
   - 어떤 방식으로 구현했는지, 주요 로직과 처리 방식 설명

1. PhotonViewSync.cs -> SafePhotonViewSync 
코디네이터 처리할 부분이 없는 경우 스킵하도록 조건 추가

2. 젠가에서 사용되는 매니저에서 OnDestroy를 이용하여 이벤트와 데이터 모두 정리

### ❓구현 의도
   - 해당 방식으로 구현한 이유, 선택한 설계 방향 공유 
1. Room Object로 Photon ViewID를 할당하는 처리를 한 미니게임의 경우 코디네이터를 사용하지 않아 멈춰버리는 현상이 있음
그래서 사용하지 않으면 생략하도록 예외처리가 필요하여 수정

2. 메인 맵에서 플레이어 한명이 나가는 경우 모든 플레이어가 나갈 수 있도록 처리하면 알아서 OnDestroy가 잔여 데이터 및 이벤트 전부 초기화 하도록 추가
<br>

## ✅ PR 체크리스트
- [x] 빌드 오류 없음
- [x] 기능 정상 작동 확인
- [x] 커밋 메시지 규칙 준수
- [x] Scene 충돌 없음