### PR TITLE
[Fix] 모바일 빌드에서 젠가가 나오지 않는 현상 수정

### DIFF
--- a/Assets/AddressableAssetsData/AssetGroups/Jenga.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Jenga.asset
@@ -22,11 +22,6 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
-  - m_GUID: 57c81c24a11382741a1a9317437a1cbb
-    m_Address: Assets/Imports/Shrimple3D LowPoly Pack
-    m_ReadOnly: 0
-    m_SerializedLabels: []
-    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 637fa8e41abec614c98e530ec2fcc2fb
     m_Address: RowPrefab
     m_ReadOnly: 0


### PR DESCRIPTION
# 🧑‍💻 PR
## 🔗 관련 이슈
- 수행한 작업과 관련 작업 번호를 작성해주세요 
- Related to: #33

## 🔥 작업 내용 요약
1. Fix - 모바일 빌드에서 젠가가 나오지 않는 현상 수정

## 💻 버그 해결방법

### 🔧 수정된 버그
에디터 환경에서는 젠가 타워가 잘 생성되지만  모바일 빌드버전에서 젠가 타워가 보이지 않는 버그

### 💡 해결방법
- 어떠한 방식을 해결을 했는지 설명
### Addressables 콘텐츠 빌드가 실패하여 데이터가 없던 것이 원인
Group에 Asset 폴더를 통째로 넣어서 그 중에 빌드 불가 파일이 있었기 때문에 콘텐츠 빌드 자체가 실패함

<img width="705" height="641" alt="image" src="https://github.com/user-attachments/assets/9292f06d-5269-4c35-b84f-9be341dd236d" />

1. 먼저 Group에 들어갑니다.

<img width="1114" height="484" alt="image" src="https://github.com/user-attachments/assets/8d16f44b-3c82-4281-a39c-894ede0bf03c" />

2. Jenga에서  Asset 폴더 통째로 있는 부분 제거

<img width="533" height="228" alt="image" src="https://github.com/user-attachments/assets/26cc384d-fb9f-45a4-9640-7880efc9a73d" />

3. Build -> Clear Build Cache -> All
예전에 만들어졌던 Addressables 산출물과 캐시를 싹 지워 이전 빌드에 잘못 들어간 항목 흔적이 남아있는 부분을 모두 제

<img width="485" height="138" alt="image" src="https://github.com/user-attachments/assets/fc928808-aac9-4c6e-be2b-47c5075e4285" />

5. New Build -> Default build Script
현재 Groups 설정을 기준으로 번들과 카탈로그를 새로 생성

### ✔️ 버그 체크리스트
- [ ] 추가로 수정이 필요함
- [x] 수정 완료
- [ ] QA 테스트 통과