### PR TITLE
[Feat] 랭킹 팔레트 색상을 TopPanel에도 적용 & [Feat] 젠가 터치 부분 터치 비활성화 & [Feat] 게임 시작 시 랭킹 미리 세팅

### DIFF
--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaBlock/ClickFace.meta
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaBlock/ClickFace.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 692b72702250665458ad994f6eeb17d3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaBlock/ClickFace/ClickFaceBuilder.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaBlock/ClickFace/ClickFaceBuilder.cs
@@ -1,0 +1,53 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class ClickFaceBuilder
+{
+    /// marginXRatio: 좌우 여백(가로 비율), marginYRatio: 위/아래 여백(세로 비율)
+    public static void AddFacesFromBox(JengaBlock b,
+        float marginXRatio = 0.02f,  // 2%
+        float marginYRatio = 0.12f,  // 12%  ← 층 사이 밴드 막힘 정도
+        float thickness = 0.002f,    // 클릭면 두께(아주 얇게)
+        float surfaceEps = 0.0005f)  // 표면에서 살짝 띄우기(붙어 보이도록)
+    {
+        // 블록 로컬 기준 크기 확보
+        var box = b.GetComponent<BoxCollider>();
+        if (!box) box = b.gameObject.AddComponent<BoxCollider>();
+        var size = box.size;
+        var half = size * 0.5f;
+
+        // 좌/우 면 (로컬 X)  → 가로는 블록의 길이(size.z)
+        CreateFace(b, "Right", Vector3.right, half.x + surfaceEps,
+            width: size.z, height: size.y,
+            marginXRatio, marginYRatio, thickness);
+
+        CreateFace(b, "Left", Vector3.left, half.x + surfaceEps,
+            width: size.z, height: size.y,
+            marginXRatio, marginYRatio, thickness);
+    }
+
+
+    private static void CreateFace(
+      JengaBlock b, string name, Vector3 localForward, float localDist,
+      float width, float height, float marginXRatio, float marginYRatio, float thickness)
+    {
+        var go = new GameObject("ClickFace_" + name);
+        go.layer = LayerMask.NameToLayer("JengaFace");
+        var t = go.transform;
+        t.SetParent(b.transform, false);
+        t.localRotation = Quaternion.LookRotation(localForward, Vector3.up);
+        t.localPosition = localForward.normalized * localDist;
+
+        // 여백 적용(비율 기반 → 에셋 크기 바뀌어도 자동 보정)
+        float w = Mathf.Max(0.0001f, width * (1f - 2f * marginXRatio));
+        float h = Mathf.Max(0.0001f, height * (1f - 2f * marginYRatio));
+
+        var bc = go.AddComponent<BoxCollider>();
+        bc.isTrigger = false;
+        bc.size = new Vector3(w, h, thickness);
+
+        var proxy = go.AddComponent<FaceHitProxy>();
+        proxy.owner = b;
+    }
+}

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaBlock/ClickFace/ClickFaceBuilder.cs.meta
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaBlock/ClickFace/ClickFaceBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f2e32ddfd6914e458e65fb99d31f54b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaBlock/ClickFace/FaceHitProxy.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaBlock/ClickFace/FaceHitProxy.cs
@@ -1,0 +1,8 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class FaceHitProxy : MonoBehaviour
+{
+    public JengaBlock owner; // 젠가 블록 중 클릭 가능한 면을 나타내는 컴포넌트
+}

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaBlock/ClickFace/FaceHitProxy.cs.meta
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaBlock/ClickFace/FaceHitProxy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c2bc5a6bdf70464c90e107d051447a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaBlock/JengaBlock.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaBlock/JengaBlock.cs
@@ -70,6 +70,13 @@ public class JengaBlock : MonoBehaviour, IPointerClickHandler
         EnsureCaches();
         _rb.isKinematic = true;
         Highlight(false);
+
+        // 로컬 BoxCollider 기준으로 클릭면 생성
+        ClickFaceBuilder.AddFacesFromBox(this,
+            marginXRatio: 0.02f,
+            marginYRatio: 0.12f,
+            thickness: 0.0015f,
+            surfaceEps: 0.0005f);
     }
 
     // 턴 전환/게임 상태에 따라 외부에서 호출

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaFocusOverlay/RawImageClickForwarder.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaFocusOverlay/RawImageClickForwarder.cs
@@ -2,6 +2,7 @@ using InputBlocker;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
+using System;
 
 /// <summary>
 /// RawImage 위 입력을 TowerCam의 Ray로 변환:
@@ -24,6 +25,7 @@ public class RawImageClickForwarder : MonoBehaviour, IPointerClickHandler, IPoin
         raw = GetComponent<RawImage>();
         rt = (RectTransform)transform;
         if (!overlay) overlay = GetComponentInParent<TowerFocusOverlay>();
+        jengaMask = LayerMask.GetMask("JengaFace");
     }
 
     public void SetMask(LayerMask mask)
@@ -47,20 +49,23 @@ public class RawImageClickForwarder : MonoBehaviour, IPointerClickHandler, IPoin
         }
 
         var hits = Physics.RaycastAll(ray, rayDistance, jengaMask);
-        System.Array.Sort(hits, (a, b) => a.distance.CompareTo(b.distance));
+        Array.Sort(hits, (a, b) => a.distance.CompareTo(b.distance));
 
-        if (hits.Length == 0) return;
-
-        var block = hits[0].collider.GetComponentInParent<JengaBlock>();
-
-        if (block != null &&
-           JengaTowerManager.Instance != null &&
-           JengaTowerManager.Instance.IsArenaMuted(block.OwnerActorNumber))
+        foreach (var h in hits)
         {
+            var proxy = h.collider.GetComponent<FaceHitProxy>();
+            if (proxy == null) continue;
+
+            var block = proxy.owner;
+
+            if (block != null &&
+                JengaTowerManager.Instance != null &&
+                JengaTowerManager.Instance.IsArenaMuted(block.OwnerActorNumber))
+                return;
+
+            overlay.NotifyBlockTapped(block);
             return;
         }
-
-        if (block != null) overlay.NotifyBlockTapped(block);
     }
 
     public void OnPointerMove(PointerEventData eventData)
@@ -100,11 +105,11 @@ public class RawImageClickForwarder : MonoBehaviour, IPointerClickHandler, IPoin
         var cam = overlay.TowerCam;
         if (cam == null) return false;
 
-        if (jengaMask == 0)
-        {
-            jengaMask = cam.cullingMask;
-            if (jengaMask == 0) return false; // 그래도 0이면 클릭 불가
-        }
+        //if (jengaMask == 0)
+        //{
+        //    jengaMask = cam.cullingMask;
+        //    if (jengaMask == 0) return false; // 그래도 0이면 클릭 불가
+        //}
 
         if (!RectTransformUtility.ScreenPointToLocalPointInRectangle(
             rt, eventData.position, eventData.pressEventCamera, out var local))

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaFocusOverlay/TowerFocusOverlay.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaFocusOverlay/TowerFocusOverlay.cs
@@ -110,6 +110,7 @@ public class TowerFocusOverlay : MonoBehaviour
         Reframe(); // 클릭한 면(_faceLocalDir) 기준으로 리프레임
     }
 
+
     private void DetachAndSanitizeCamera()
     {
         var t = towerCam.transform;
@@ -167,7 +168,8 @@ public class TowerFocusOverlay : MonoBehaviour
     {
         arenaMask = mask;
         if (towerCam) towerCam.cullingMask = mask;
-        if (forwarder) forwarder.SetMask(mask);
+        if (forwarder) forwarder.SetMask(LayerMask.GetMask("JengaFace"));
+        //if (forwarder) forwarder.SetMask(mask);
     }
 
     /// <summary>
@@ -325,6 +327,7 @@ public class TowerFocusOverlay : MonoBehaviour
     public void NotifyHover(JengaBlock block)
     {
         if (!active) return;
+
         if (hovered == block) return;
 
         // 이전 호버 끄기(선택된 블록과 다를 때만)

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaGameManager/JengaGameManager.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaGameManager/JengaGameManager.cs
@@ -64,6 +64,14 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
     private Dictionary<string, bool> playerFinished = new();     // 플레이어별 게임 완료 여부
     public Dictionary<string, int> GetCurrentRanks() => CalculateRankings();
 
+    private readonly Dictionary<string, int> _gridOrder = new(); // uid -> 0,1,2,...
+    private int GridOrderOf(string uid) => _gridOrder.TryGetValue(uid, out var v) ? v : int.MaxValue;
+
+    private static bool IsActive(JengaPlayerData d)
+    => d.removedCount > 0 || d.score > 0 || d.lastSuccessTime > 0f || !d.isAlive;
+
+    private Dictionary<string, int> _lastRankSnapshot;
+
     private double? _roomStartTime;
     private double? _roomDuration;
     private Coroutine _timerCo;
@@ -114,9 +122,6 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
                 continue;
             }
 
-            //// UID를 기반으로 PlayerManager에서 해당 플레이어의 GamePlayer 객체를 가져옴
-            //var gamePlayer = PlayerManager.Instance.GetPlayer(uid);
-
             // CreateOrGetPlayer를 사용하여 플레이어가 없으면 자동 생성
             var gamePlayer = PlayerManager.Instance.CreateOrGetPlayer(uid, photonPlayer.NickName);
 
@@ -143,6 +148,20 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
             }
         }
         Debug.Log($"[JengaGameManager - InitializePlayers] Initialized {players.Count} players");
+
+        if (PhotonNetwork.IsMasterClient)
+        {
+            var uidList = PhotonNetwork.PlayerList
+                .OrderBy(p => p.ActorNumber)
+                .Select(p => p.CustomProperties["uid"] as string)
+                .Where(uid => !string.IsNullOrEmpty(uid))
+                .ToList();
+
+            SetGridOrder(uidList);
+
+            // 시작 직후 보이는 초기 순위
+            SeedInitialRanksFromGrid();
+        }
     }
 
     #endregion
@@ -432,8 +451,10 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
         SendResultToMainGame(rankings);
     }
 
+    // 어디서든 랭킹이 확정/수신될 때 캐싱
     public void ApplyRankSnapshot(Dictionary<string, int> ranks)
     {
+        _lastRankSnapshot = new Dictionary<string, int>(ranks);
         OnRankingsUpdated?.Invoke(ranks);
     }
 
@@ -441,10 +462,12 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
     {
         // 점수순으로 정렬, 동점일 경우 생존 여부로 판단
         var sortedPlayers = players
-            .OrderByDescending(p => p.Value.removedCount)   // 1순위: 더 많이 뺀 사람
-            .ThenBy(p => p.Value.lastSuccessTime)           // 2순위: 더 빨리 성공한 사람
-            .ThenByDescending(p => p.Value.score)           // 3순위: (같은 개수/시간일 때) 점수 큰 사람
-            .ToList();
+        .OrderByDescending(p => IsActive(p.Value))      // 활동 여부: 활동한 사람(true) 먼저 (혹시나 전부 잠수타서 움직이지 않는 경우 대비)
+        .ThenByDescending(p => p.Value.removedCount)    // 1순위 : 젠가 블록을 더 많이 뺀 사람
+        .ThenBy(p => p.Value.lastSuccessTime)           // 2순위 : 동점일 때 제거를 더 빨리 성공(작을수록 유리)
+        .ThenByDescending(p => p.Value.score)           // 3순위 : 점수 큰 사람
+        .ThenBy(p => GridOrderOf(p.Key))                // 4순위 : 초기 그리드
+        .ToList();
 
         // 딕셔너리 형태로 UID별 순위를 저장
         // { "playerA": 1, "playerB": 2, "playerC": 3, "playerD": 4 }
@@ -459,6 +482,8 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
 
         return rankings;
     }
+
+
 
     /// <summary>
     /// 점수 순위를 메인 게임 시스템에 전달하고,
@@ -664,8 +689,65 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
         return players.Count(kv => kv.Value.isAlive);
     }
 
+    #region 게임 시작 시 랭킹 그리드 순서 설정
 
-    #region 강제 정리 (플레이어 1명이라도 이탈 시 호출)
+    /// <summary>
+    /// 마스터가 게임 시작 시 그리드 순서 확정
+    /// </summary>
+    /// <param name="uidList"></param>
+    public void SetGridOrder(IList<string> uidList)
+    {
+        _gridOrder.Clear();
+        for (int i = 0; i < uidList.Count; i++) _gridOrder[uidList[i]] = i;
+    }
+
+    /// <summary>
+    /// 그리드 순서에 따라 초기 랭킹 설정
+    /// </summary>
+    public void SeedInitialRanksFromGrid()
+    {
+        if (_gridOrder.Count == 0) return;
+
+        var rankMap = _gridOrder
+            .OrderBy(kv => kv.Value)
+            .Select((kv, idx) => new { kv.Key, Rank = idx + 1 })
+            .ToDictionary(x => x.Key, x => x.Rank);
+
+        _lastRankSnapshot = new Dictionary<string, int>(rankMap);
+        // UI/네트워크에 즉시 반영
+        OnRankingsUpdated?.Invoke(rankMap);
+        JengaNetworkManager.Instance?.BroadcastRankSnapshot(rankMap);
+
+        // 룸 프로퍼티에도 기록해서 늦게 들어온 클라 동기화
+        if (PhotonNetwork.IsMasterClient && PhotonNetwork.InRoom)
+        {
+            var uids = rankMap.Keys.ToArray();
+            var ranks = rankMap.Values.ToArray();
+            var props = new Hashtable
+            {
+                { JengaRoomProps.KEY_RANK_UIDS, uids },
+                { JengaRoomProps.KEY_RANK_VALS, ranks },
+            };
+            PhotonNetwork.CurrentRoom.SetCustomProperties(props);
+        }
+    }
+
+    // 필요 시 UI가 꺼내갈 수 있게 getter 제공
+    public bool TryGetLastRankSnapshot(out Dictionary<string, int> ranks)
+    {
+        if (_lastRankSnapshot != null)
+        {
+            ranks = new Dictionary<string, int>(_lastRankSnapshot);
+            return true;
+        }
+        ranks = null;
+        return false;
+    }
+
+    #endregion 
+
+
+    #region 강제 정리
 
     protected override void OnDestroy()
     {
@@ -699,8 +781,6 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
                 { JengaRoomProps.KEY_STATE, null },
                 { JengaRoomProps.KEY_START_TIME, null },
                 { JengaRoomProps.KEY_DURATION, null },
-                { JengaRoomProps.KEY_RANK_UIDS, null },
-                { JengaRoomProps.KEY_RANK_VALS, null }
             };
             PhotonNetwork.CurrentRoom.SetCustomProperties(clearProps);
         }

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaNetwork/JengaNetworkManager.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaNetwork/JengaNetworkManager.cs
@@ -84,7 +84,11 @@ public class JengaNetworkManager : PunSingleton<JengaNetworkManager>, IGameCompo
         JengaGameManager.Instance.ApplyPlayerActionResult(uid, success, score);
 
         var ranks = JengaGameManager.Instance?.GetCurrentRanks();
-        if (ranks != null) BroadcastRankSnapshot(ranks);
+        if (ranks != null)
+        {
+            BroadcastRankSnapshot(ranks);
+            RPC_SyncRanks(ranks.Keys.ToArray(), ranks.Values.ToArray());
+        }
     }
 
     #endregion
@@ -685,7 +689,6 @@ public class JengaNetworkManager : PunSingleton<JengaNetworkManager>, IGameCompo
     public override void OnRoomPropertiesUpdate(PhotonHashtable props)
     {
         if (_receivedRankOnce) return;
-        if (PhotonNetwork.IsMasterClient) return;
 
         if (props.TryGetValue(JengaRoomProps.KEY_RANK_UIDS, out var uObj) &&
             props.TryGetValue(JengaRoomProps.KEY_RANK_VALS, out var vObj) &&

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaTower/JengaTowerManager.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaTower/JengaTowerManager.cs
@@ -53,6 +53,19 @@ public class JengaTowerManager : CombinedSingleton<JengaTowerManager>, IGameComp
     private Coroutine _collapseReleaseCo;
     private int _collapseNesting = 0;
 
+    #region JengaFace Layer 캐싱
+    private static int _jengaFaceLayer = int.MinValue;
+    private static int JengaFaceLayer
+    {
+        get
+        {
+            if (_jengaFaceLayer == int.MinValue)
+                _jengaFaceLayer = LayerMask.NameToLayer("JengaFace");
+            return _jengaFaceLayer;
+        }
+    }
+    #endregion
+
     // 개별 타워별로 구독한 델리게이트를 보관(해제용)
     private readonly HashSet<int> _mutedActors = new();
     private readonly Dictionary<int, (Action on, Action off)> _towerMuteHandlers = new();
@@ -639,6 +652,15 @@ public class JengaTowerManager : CombinedSingleton<JengaTowerManager>, IGameComp
 
     private static void SetLayerRecursively(GameObject go, int layer)
     {
+        // 1) 클릭 면은 보존
+        if (go.layer == JengaFaceLayer || go.GetComponent<FaceHitProxy>() != null)
+        {
+            foreach (Transform c in go.transform)
+                SetLayerRecursively(c.gameObject, JengaFaceLayer);
+            return;
+        }
+
+        // 2) 일반 오브젝트만 아레나 레이어 적용
         go.layer = layer;
 
         foreach (Transform c in go.transform)

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaUIManager/JengaUIManager.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaUIManager/JengaUIManager.cs
@@ -66,6 +66,8 @@ public class JengaUIManager : CombinedSingleton<JengaUIManager>, IGameComponent
             if (rankingUI != null) rankingUI.OpenForLive();
         }
 
+        PrimeRankingUIIfPossible();
+
         Debug.Log("[JengaUIManager - Initialize] UI 매니저 초기화 완료");
     }
 
@@ -80,6 +82,7 @@ public class JengaUIManager : CombinedSingleton<JengaUIManager>, IGameComponent
                 // 게임 시작 시 카운트다운 UI 숨김 (혹시 남아있을 경우를 대비)
                 HideCountdown();
                 if (rankingUI != null) rankingUI.OpenForLive();
+                PrimeRankingUIIfPossible();
 
                 _iAmEliminated = false;
                 if (waitingPanel) waitingPanel.SetActive(false);
@@ -314,6 +317,33 @@ public class JengaUIManager : CombinedSingleton<JengaUIManager>, IGameComponent
         HideRotateButton(); // 조작 불가
     }
 
+    private void PrimeRankingUIIfPossible()
+    {
+        if (rankingUI == null || JengaGameManager.Instance == null) return;
+
+        // 룸 프로퍼티에서 읽기
+        Dictionary<string, int> ranks = null;
+        var room = PhotonNetwork.CurrentRoom;
+        if (room != null &&
+            room.CustomProperties.TryGetValue(JengaRoomProps.KEY_RANK_UIDS, out var uObj) &&
+            room.CustomProperties.TryGetValue(JengaRoomProps.KEY_RANK_VALS, out var vObj) &&
+            uObj is string[] uids && vObj is int[] vals && uids.Length > 0)
+        {
+            ranks = new Dictionary<string, int>();
+            for (int i = 0; i < uids.Length && i < vals.Length; i++)
+                ranks[uids[i]] = vals[i];
+        }
+
+        // 없으면 GameManager 캐시 사용
+        if (ranks == null && JengaGameManager.Instance.TryGetLastRankSnapshot(out var snap))
+            ranks = snap;
+
+        if (ranks != null && ranks.Count > 0)
+        {
+            rankingUI.OpenForLive();
+            rankingUI.UpdateLiveRanks(ranks);
+        }
+    }
 
     #endregion
 

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaUIManager/TopPanelColorBinder.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaUIManager/TopPanelColorBinder.cs
@@ -1,0 +1,81 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Photon.Pun;
+using UnityEngine;
+using UnityEngine.UI;
+
+public enum UidSource 
+{ 
+    LocalPlayer, 
+    CurrentTurn, // 혹시 턴이 있는 게임에서 쓸 수도 있으니 남겨둠
+    Custom 
+}
+
+public class TopPanelColorBinder : MonoBehaviour
+{
+    [Header("Source")]
+    [SerializeField] private UidSource uidSource = UidSource.LocalPlayer;
+    [SerializeField] private string customUid; // UidSource.Custom 일 때 사용
+    [SerializeField] private JengaRankingUIAnimated provider; // 비워두면 FindObjectOfType로 찾음
+
+    [Header("Targets")]
+    [SerializeField] private Graphic[] targets; // Image, TMP_Text, Outline 등 원하는 만큼 할 수 있도록
+
+    [Header("Options")]
+    [SerializeField] private float targetAlpha = 1f;
+    [SerializeField] private bool applyOnStart = true;
+
+    private void Awake()
+    {
+        if (!provider) provider = FindObjectOfType<JengaRankingUIAnimated>(true);
+        if (provider) provider.OnPaletteChanged += HandlePaletteChanged;
+    }
+
+    private void Start()
+    {
+        if (applyOnStart) ApplyNow();
+    }
+
+    private void OnDestroy()
+    {
+        if (provider) provider.OnPaletteChanged -= HandlePaletteChanged;
+    }
+
+    private void HandlePaletteChanged()
+    {
+        ApplyNow();
+    }
+
+    public void ApplyNow()
+    {
+        if (!provider || targets == null || targets.Length == 0) return;
+
+        var uid = ResolveUid();
+        if (string.IsNullOrEmpty(uid)) return;
+
+        if (provider.TryGetColor(uid, out var c))
+        {
+            foreach (var g in targets.Where(t => t))
+            {
+                var col = c;
+                col.a = targetAlpha <= 0 ? g.color.a : targetAlpha;
+                g.color = col;
+            }
+        }
+    }
+
+    private string ResolveUid()
+    {
+        switch (uidSource)
+        {
+            case UidSource.LocalPlayer:
+                return PhotonNetwork.LocalPlayer?.CustomProperties?["uid"] as string;
+            case UidSource.CurrentTurn:
+                return PhotonNetwork.LocalPlayer?.CustomProperties?["uid"] as string;
+            case UidSource.Custom:
+                return customUid;
+        }
+        return null;
+    }
+}

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaUIManager/TopPanelColorBinder.cs.meta
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaUIManager/TopPanelColorBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8119e64d6400df24b9b4f58c0413c1f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LTH/LTH_Scripts/Ranks/JengaRankingUIAnimated.cs
+++ b/Assets/LTH/LTH_Scripts/Ranks/JengaRankingUIAnimated.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.ResourceManagement.AsyncOperations;
 using UnityEngine.UI;
+using System;
 
 /// <summary>
 /// 젠가 랭킹 패널 컨트롤러 (DOTween 전용)
@@ -41,6 +42,14 @@ public class JengaRankingUIAnimated : MonoBehaviour
     [Header("Live Update")]
     [Tooltip("실시간 순위 반영 최소 간격(초)")]
     [SerializeField] private float minUpdateInterval = 0.08f;
+
+    #region 플레이어 마다 색이 변경되는 부분 공유 API
+    public event Action OnPaletteChanged;
+    public bool TryGetColor(string uid, out Color c) => _uidColor.TryGetValue(uid, out c);
+    public IReadOnlyDictionary<string, Color> GetColorMap() => _uidColor;
+    private void NotifyPaletteChanged() => OnPaletteChanged?.Invoke();
+
+    #endregion
 
     private readonly Dictionary<string, RankingRow> _rows = new();
     private readonly Dictionary<string, AsyncOperationHandle<GameObject>> _rowHandles = new();
@@ -135,6 +144,7 @@ public class JengaRankingUIAnimated : MonoBehaviour
             firstRow.EmphasizeFirstPlace();
 
         SnapshotRanks(uidToRank);
+        NotifyPaletteChanged();
     }
 
     public void Hide() => ClosePanel();
@@ -148,6 +158,8 @@ public class JengaRankingUIAnimated : MonoBehaviour
         _lastRanks.Clear();
         _moveTweens.Clear();
         _creating.Clear();
+        _uidColor.Clear();
+        NotifyPaletteChanged();
     }
 
     // ======================= 실시간 갱신 =======================
@@ -215,14 +227,16 @@ public class JengaRankingUIAnimated : MonoBehaviour
             int delta = oldRank - rank;
 
             row.SetColor(ResolveColor(uid));
-            if (delta != 0) row.SetRankAnimated(rank);
-            else row.SetContent(rank);
-            row.SetFirstPlace(rank == 1);
-
+            
             if (delta != 0)
             {
+                row.SetRankAnimated(rank);
                 row.ShowDeltaIcon(delta);
                 row.PlayDeltaFx(delta, rank);
+            }
+            else
+            {
+                row.SetContent(rank);
             }
         }
 
@@ -230,6 +244,7 @@ public class JengaRankingUIAnimated : MonoBehaviour
         SmoothReorderByLayout(CollectRowsInOrder(ordered), moveDuration);
 
         SnapshotRanks(newRanks);
+        NotifyPaletteChanged();
     }
 
 
@@ -505,6 +520,7 @@ public class JengaRankingUIAnimated : MonoBehaviour
             _uidColor[uid] = chosen;
             _usedColors.Add(chosen);
         }
+        NotifyPaletteChanged();
     }
 
     private Color ResolveColor(string uid)

--- a/Assets/LTH/LTH_Scripts/Ranks/RankingRow.cs
+++ b/Assets/LTH/LTH_Scripts/Ranks/RankingRow.cs
@@ -20,8 +20,7 @@ public class RankingRow : MonoBehaviour
     [SerializeField] private float trophyFade = 0.15f;
     [SerializeField] private float trophyPunch = 0.18f;
     private Tween _trophyTween;
-
-
+    private bool _isFirstShown; // 현재 트로피 표시 상태 캐시 (계속 확대가 되는 현상 방지)
 
     [Header("Delta Icon (▲/▼)")]
     [SerializeField] private Image deltaIcon;           // 아이콘 이미지(작은 화살표)
@@ -43,6 +42,10 @@ public class RankingRow : MonoBehaviour
     [SerializeField] private Color upColor = new Color(0.30f, 0.85f, 0.40f, 1f);
     [SerializeField] private Color downColor = new Color(0.95f, 0.30f, 0.30f, 1f);
     [SerializeField] private float deltaFlash = 0.25f;
+
+    [Header("FX Root (펀치/연출 전용)")]
+    [SerializeField] private Transform fxRoot;
+    private float _fxBaseScale = 1f;
 
     private RectTransform _rt;
     private float _baseScale = 1f;
@@ -67,6 +70,15 @@ public class RankingRow : MonoBehaviour
         _baseScale = transform.localScale.x;
         ResetView();
 
+        _isFirstShown = false;
+
+        if (!fxRoot)
+        {
+            fxRoot = transform; // 없으면 자기 자신 사용(점진 전환)
+        }
+
+        _fxBaseScale = fxRoot.localScale.x;
+
         if (deltaIcon)
         {
             var col = deltaIcon.color; col.a = 0f;
@@ -87,7 +99,6 @@ public class RankingRow : MonoBehaviour
     {
         if (rankText) rankText.text = rank.ToString();
         if (bg && !UseBgAsChip) bg.color = normalColor;
-        SetFirstPlace(rank == 1);
     }
 
     // === 실시간용: 이름은 그대로, 순위 숫자만 '플립' 후 셋 ===
@@ -95,7 +106,6 @@ public class RankingRow : MonoBehaviour
     {
         if (!rankText) return;
 
-        // 숫자 플립: ScaleY 1→0 (변경) → 0→1
         Sequence seq = DOTween.Sequence();
         seq.Append(rankText.transform.DOScaleY(0f, 0.12f))
            .AppendCallback(() =>
@@ -111,7 +121,14 @@ public class RankingRow : MonoBehaviour
     {
         if (!trophyIcon) return;
 
-        _trophyTween?.Kill();
+        // 상태 변화 없으면 무시
+        if (_isFirstShown == isFirst) return;
+        _isFirstShown = isFirst;
+
+        _trophyTween?.Kill(false);
+        // 다음 트윈을 항상 동일 기준에서 시작 (계속 확대가 되면 안됨)
+        trophyIcon.transform.localScale = Vector3.one;
+
         if (isFirst)
         {
             _trophyTween = DOTween.Sequence()
@@ -147,10 +164,10 @@ public class RankingRow : MonoBehaviour
     public void EmphasizeFirstPlace()
     {
         KillFx();
-        cg.alpha = 0f;
-        _fadeTween = cg.DOFade(1f, Mathf.Max(0.01f, fadeInDuration));
-        transform.localScale = Vector3.one * _baseScale;
-        _punchTween = transform.DOPunchScale(Vector3.one * punchScale, punchDuration, vibrato: 10, elasticity: 0.9f);
+        if (cg) cg.alpha = 0f;
+
+        fxRoot.localScale = Vector3.one * _fxBaseScale;
+        _punchTween = fxRoot.DOPunchScale(Vector3.one * punchScale, punchDuration, 10, 0.9f);
     }
 
     public void PlayDeltaFx(int delta, int newRank)
@@ -165,8 +182,9 @@ public class RankingRow : MonoBehaviour
 
         if (punchScale > 0f)
         {
-            _punchTween?.Kill();
-            _punchTween = transform.DOPunchScale(Vector3.one * punchScale, punchDuration, vibrato: 8, elasticity: 0.8f);
+            _punchTween?.Kill(false);
+            fxRoot.localScale = Vector3.one * _fxBaseScale;
+            _punchTween = fxRoot.DOPunchScale(Vector3.one * punchScale, punchDuration, 8, 0.8f);
         }
     }
 
@@ -203,8 +221,10 @@ public class RankingRow : MonoBehaviour
 
     private void KillFx()
     {
-        _fadeTween?.Kill(); _punchTween?.Kill();
+        _fadeTween?.Kill(); 
+        _punchTween?.Kill();
         _fadeTween = _punchTween = null;
+        if (fxRoot) fxRoot.localScale = Vector3.one * _fxBaseScale;
     }
     private void KillFlash() { _flashTween?.Kill(); _flashTween = null; }
     private void KillAllTweens()

--- a/Assets/Scenes/MiniGameJengaScene.unity
+++ b/Assets/Scenes/MiniGameJengaScene.unity
@@ -856,46 +856,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!21 &152935812
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
-    - _WidthHeightRadius: {r: 149.651, g: 51.939, b: 40, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1001 &197854449
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1008,12 +968,12 @@ PrefabInstance:
     - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0.12083333
       objectReference: {fileID: 0}
     - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1.0007457
+      value: 0.38148147
       objectReference: {fileID: 0}
     - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
         type: 3}
@@ -1592,7 +1552,7 @@ MonoBehaviour:
   overlay: {fileID: 760830006}
   jengaMask:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 65536
   compensateLetterbox: 1
   ignoreClicksOutsideDraw: 1
   rayDistance: 100
@@ -2024,7 +1984,7 @@ Transform:
   m_GameObject: {fileID: 330585543}
   serializedVersion: 2
   m_LocalRotation: {x: 0.039529894, y: 0.95894593, z: -0.16587429, w: 0.2265963}
-  m_LocalPosition: {x: -264.6, y: 11.2, z: -152.4}
+  m_LocalPosition: {x: -264.84, y: 10.8, z: -152.4}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2776,7 +2736,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 0, y: 80.158}
+  m_AnchoredPosition: {x: 0, y: 80.1582}
   m_SizeDelta: {x: 1082, y: 160.317}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &407208381
@@ -2977,7 +2937,7 @@ PrefabInstance:
     - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1.0007457
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
         type: 3}
@@ -4887,9 +4847,19 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3226987432599523960, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3879852811759145387, guid: fe50d52b558578d43beb59995e9a9ca4,
         type: 3}
       propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4550220700672617421, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4625638008536974983, guid: fe50d52b558578d43beb59995e9a9ca4,
@@ -4962,6 +4932,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7500476990348501097, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7830282080685953408, guid: fe50d52b558578d43beb59995e9a9ca4,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -5012,6 +4987,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8068020423338431611, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8280847053682877144, guid: fe50d52b558578d43beb59995e9a9ca4,
         type: 3}
       propertyPath: m_Enabled
@@ -5038,7 +5018,11 @@ PrefabInstance:
       value: -3.58
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
+    m_RemovedGameObjects:
+    - {fileID: 3226987432599523960, guid: fe50d52b558578d43beb59995e9a9ca4, type: 3}
+    - {fileID: 8068020423338431611, guid: fe50d52b558578d43beb59995e9a9ca4, type: 3}
+    - {fileID: 4550220700672617421, guid: fe50d52b558578d43beb59995e9a9ca4, type: 3}
+    - {fileID: 7500476990348501097, guid: fe50d52b558578d43beb59995e9a9ca4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fe50d52b558578d43beb59995e9a9ca4, type: 3}
@@ -5406,6 +5390,46 @@ Material:
     - _OuterUV: {r: 0, g: 0, b: 0.99999994, a: 1}
     - _WidthHeightRadius: {r: 1275.0493, g: 849.3999, b: 80, a: 0}
   m_BuildTextureStacks: []
+--- !u!21 &829585272
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0.024052067, g: 0.022535274, b: 0.9789449, a: 0.9755116}
+    - _WidthHeightRadius: {r: 1192.5742, g: 319.42212, b: 80, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1 &832575517
 GameObject:
   m_ObjectHideFlags: 0
@@ -5521,7 +5545,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 152935812}
+  m_Material: {fileID: 1474155264}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
@@ -6235,6 +6259,46 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1.1, y: 1, z: 1.1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!21 &954090827
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 0.99999994, a: 1}
+    - _WidthHeightRadius: {r: 1275.0493, g: 849.3999, b: 80, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1 &956063944
 GameObject:
   m_ObjectHideFlags: 0
@@ -6840,7 +6904,7 @@ PrefabInstance:
     - target: {fileID: 1217284196904556031, guid: bd6c411af2463804291825c789c17218,
         type: 3}
       propertyPath: gameTime
-      value: 10
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: 1217284196904556031, guid: bd6c411af2463804291825c789c17218,
         type: 3}
@@ -7799,7 +7863,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 978, y: -90}
+  m_AnchoredPosition: {x: 982, y: -290}
   m_SizeDelta: {x: 157.32251, y: 142.82007}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1375761814
@@ -7974,7 +8038,7 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1438362380}
   m_PrefabAsset: {fileID: 0}
---- !u!21 &1458854453
+--- !u!21 &1474155264
 Material:
   serializedVersion: 8
   m_ObjectHideFlags: 0
@@ -8011,8 +8075,8 @@ Material:
     - _StencilWriteMask: 255
     - _UseUIAlphaClip: 0
     m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 0.99999994, a: 1}
-    - _WidthHeightRadius: {r: 1275.0493, g: 849.3999, b: 80, a: 0}
+    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
+    - _WidthHeightRadius: {r: 149.651, g: 51.939, b: 40, a: 0}
   m_BuildTextureStacks: []
 --- !u!1001 &1496346194
 PrefabInstance:
@@ -9683,7 +9747,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -902, y: -170}
+  m_AnchoredPosition: {x: -902, y: -189}
   m_SizeDelta: {x: 49.13, y: 218.999}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &1648873811
@@ -9706,8 +9770,8 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: d05530cc60c905a4e89e72ee01729448, type: 3}
-  m_Type: 0
+  m_Sprite: {fileID: 21300000, guid: 38e324f2965ad4660b4aefaba2575df8, type: 3}
+  m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -10446,46 +10510,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7ad8cbc5154a7f8429da4c6fdb4c362b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!21 &1863447743
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0.024052067, g: 0.022535274, b: 0.9789449, a: 0.9755116}
-    - _WidthHeightRadius: {r: 1192.5742, g: 319.42212, b: 80, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1 &1867122145
 GameObject:
   m_ObjectHideFlags: 0
@@ -10809,6 +10833,8 @@ GameObject:
   - component: {fileID: 1934672923}
   - component: {fileID: 1934672922}
   - component: {fileID: 1934672921}
+  - component: {fileID: 1934672925}
+  - component: {fileID: 1934672924}
   m_Layer: 5
   m_Name: TopPanel
   m_TagString: Untagged
@@ -10833,8 +10859,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: -93.51007}
-  m_SizeDelta: {x: 1082, y: 186.98}
+  m_AnchoredPosition: {x: -0.5, y: -93.510254}
+  m_SizeDelta: {x: 1081, y: 186.98}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1934672921
 MonoBehaviour:
@@ -10882,7 +10908,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 211fbaf7fa0004e158870d1ecb769fd2, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 9aa2a0cee233f40aab034a146d8bb4b6, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -10900,6 +10926,37 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1934672919}
   m_CullTransparentMesh: 1
+--- !u!225 &1934672924
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1934672919}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!114 &1934672925
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1934672919}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8119e64d6400df24b9b4f58c0413c1f4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uidSource: 0
+  customUid: 
+  provider: {fileID: 1648873813}
+  targets:
+  - {fileID: 1934672922}
+  targetAlpha: 1
+  applyOnStart: 1
 --- !u!1 &1937771132
 GameObject:
   m_ObjectHideFlags: 0

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -30,7 +30,7 @@ TagManager:
   - Arena_2
   - Arena_3
   - JengaBlock
-  - SwipePlane
+  - JengaFace
   - 
   - 
   - 


### PR DESCRIPTION
# 🧑‍💻 PR

## 🔥 작업 내용 요약
1. [Feat] 랭킹 팔레트 색상을 TopPanel에도 적용
2. [Feat] 젠가 터치 부분 터치 비활성화
3. [Feat] 게임 시작 시 랭킹 미리 세팅

## 💻 작업 구현 방법
### 📝 구현 설명

## 1. 랭킹 팔레트 색상을 TopPanel에도 적용

### 구현방법
1. JengaRankingUIAnimated가 사용하는 UID→Color 팔레트를 외부에 공개하고 변경 이벤트를 발행
2. TopPanel에 TopPanelColorBinder 컴포넌트를 추가하여 LocalPlayer UID 색을 자동 반영

## 2. 젠가 터치 부분 터치 비활성화
<img width="293" height="289" alt="image" src="https://github.com/user-attachments/assets/d5971915-09b3-44bf-af15-ffc5fe38c295" />

### 구현 방법
1. 선택적 입력용 자식 콜라이더(ClickFace_)를 블록에 부착해, 이들만 레이캐스트 대상으로 사용
2. 정면 밴드 차단을 위해 Forward/Back 면은 입력 대상에서 제외하고, Left/Right만 생성
3. 레이캐스트는 항상 JengaFace 레이어만 맞추도록 고정

## 3. 게임 시작 시 랭킹 미리 세팅

### 구현방법
1. ActorNumber 오름차순(= 포톤이 보장하는 조인 순)으로 UID 리스트 생성
2. 그 리스트로 그리드 순서를 확정(SetGridOrder)
3. 그리드 순서를 초기 랭킹으로 브로드캐스트 + Room Properties 저장(SeedInitialRanksFromGrid)

---
### ❓구현 의도
1. 랭킹 팔레트 색상을 TopPanel에도 적용
- 랭킹에 닉네임을 넣지 않기 때문에 TopPanel에 색을 넣어 자신 어떤 색인지 알 수 있도록 만듦
4. 젠가 터치 부분 터치 비활성화
- 카메라 확대시 위 사진 부분이 터치가 되면 어색한 부분이 있어 클릭을 제한
5. 게임 시작 시 랭킹 미리 세팅
게임을 진행해야 랭킹이 업데이트 되는 방식이라 카트라이더 처럼 처음부터 랭킹을 세팅한 상태에서 업데이트 하는 것이 더 자연스러운 연출로 생각

## ✅ PR 체크리스트
- [x] 빌드 오류 없음
- [x] 기능 정상 작동 확인
- [x] 커밋 메시지 규칙 준수
- [x] Scene 충돌 없음