### PR TITLE
[Fix] 게임 입장 시간 차이로 인한 타이머 호출 오류 & [Fix] 젠가맵 재배치

### DIFF
--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaGameManager/JengaGameManager.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaGameManager/JengaGameManager.cs
@@ -75,6 +75,7 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
     private double? _roomStartTime;
     private double? _roomDuration;
     private Coroutine _timerCo;
+    private Coroutine _timerWatchdog;
 
     // 게임 종료 후 입력 차단
     private InputLockToken _endGameLock;
@@ -92,11 +93,29 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
 
         InitializePlayers(); // 플레이어 정보 세팅
         currentState = JengaGameState.Waiting;
+        
         remainingTime = gameTime;
+        OnTimeUpdated?.Invoke(remainingTime); // UI 초기값 3:00 표시
 
         JengaUIManager.Instance?.HideRotateButton();
 
         Debug.Log("[JengaGameManager - Initialize] 초기화 완료");
+
+        // 이미 기록된 ROOM PROPS가 있으면 즉시 적용(레이트 조인/타이밍 보정)
+        // 다른 클라이언트의 접속 순서에 상관없이 동기화 보장
+        if (PhotonNetwork.InRoom)
+        {
+            var table = PhotonNetwork.CurrentRoom.CustomProperties;
+            if (JengaRoomProps.TryGet<double>(table, JengaRoomProps.KEY_START_TIME, out var st) &&
+                JengaRoomProps.TryGet<double>(table, JengaRoomProps.KEY_DURATION, out var du))
+            {
+                ApplySyncedTimerFromRoomProps(st, du); // 내부에서 TryStartRoomPropTimer() 호출됨
+            }
+            if (JengaRoomProps.TryGet<int>(table, JengaRoomProps.KEY_STATE, out var stateInt))
+            {
+                ApplyGameStateChange((JengaGameState)stateInt);
+            }
+        }
 
         // 초기화 완료 후 카운트다운 시작 (마스터만)
         if (PhotonNetwork.IsMasterClient)
@@ -186,6 +205,20 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
             return;
         }
 
+        if (useCountdown && _roomStartTime.HasValue && PhotonNetwork.Time < _roomStartTime.Value)
+        {
+            return;
+        }
+
+        if (!useCountdown)
+        {
+            var props = new Hashtable {
+            { JengaRoomProps.KEY_START_TIME, PhotonNetwork.Time },
+            { JengaRoomProps.KEY_DURATION,   (double)gameTime }
+        };
+            PhotonNetwork.CurrentRoom.SetCustomProperties(props);
+        }
+
         // 1) 마스터 로컬 먼저 Playing 세팅
         Debug.Log("[JengaGameManager] Step 1: ApplyGameStateChange(Playing)");
         ApplyGameStateChange(JengaGameState.Playing);
@@ -194,19 +227,17 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
         Debug.Log("[JengaGameManager] Step 2: BroadcastGameState(Playing)");
         JengaNetworkManager.Instance.BroadcastGameState(JengaGameState.Playing);
 
-        // 3) 타이머는 카운트다운이 완전히 끝난 후에만 시작
-        Debug.Log("[JengaGameManager] Step 3: StartCoroutine(GameTimer)");
-        if (!useCountdown && PhotonNetwork.IsMasterClient)
-        {
-            var props = new Hashtable
-    {
-        { JengaRoomProps.KEY_START_TIME, PhotonNetwork.Time },
-        { JengaRoomProps.KEY_DURATION,   (double)gameTime }
-    };
-            PhotonNetwork.CurrentRoom.SetCustomProperties(props);
-        }
-
-        StartCoroutine(GameTimer());
+        //    // 3) 타이머는 카운트다운이 완전히 끝난 후에만 시작
+        //    Debug.Log("[JengaGameManager] Step 3: StartCoroutine(GameTimer)");
+        //    if (!useCountdown && PhotonNetwork.IsMasterClient)
+        //    {
+        //        var props = new Hashtable
+        //{
+        //    { JengaRoomProps.KEY_START_TIME, PhotonNetwork.Time },
+        //    { JengaRoomProps.KEY_DURATION,   (double)gameTime }
+        //};
+        //        PhotonNetwork.CurrentRoom.SetCustomProperties(props);
+        //    }
     }
 
     #region 카운트다운 관련
@@ -225,24 +256,19 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
     /// </summary>
     public void StartGameWithCountdown()
     {
-        if (!PhotonNetwork.IsMasterClient)
-        {
-            Debug.Log("[JengaGameManager] Not master client - waiting for countdown broadcast");
-            return;
-        }
+        if (!PhotonNetwork.IsMasterClient) return;
+        if (currentState == JengaGameState.Finished) return;
 
-        if (currentState == JengaGameState.Finished)
-        {
-            Debug.Log("[JengaGameManager] Skip countdown: game already finished");
-            return;
-        }
-
-        // 바로 Playing 상태로 변경
-        ApplyGameStateChange(JengaGameState.Playing);
-        JengaNetworkManager.Instance?.BroadcastGameState(JengaGameState.Playing);
 
         if (useCountdown)
         {
+            // 카운트다운 시작 전에, 모두가 공유할 "미래 시각"을 기록 (START_TIME 고정)
+            double startAt = PhotonNetwork.Time + countdownDuration + 1.0; // "START!" 1초 표시 포함
+            PhotonNetwork.CurrentRoom.SetCustomProperties(new Hashtable {
+            { JengaRoomProps.KEY_START_TIME, startAt },
+            { JengaRoomProps.KEY_DURATION,   (double)gameTime }
+        });
+
             // 네트워크 매니저를 통해 모든 클라이언트에게 카운트다운 시작 신호
             JengaNetworkManager.Instance?.BroadcastStartCountdown(countdownDuration);
 
@@ -251,7 +277,12 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
         }
         else
         {
-            // 카운트다운 없이 바로 게임 시작
+            // 카운트다운 없이 바로 시작할 땐 지금 시각 기준
+            PhotonNetwork.CurrentRoom.SetCustomProperties(new Hashtable {
+            { JengaRoomProps.KEY_START_TIME, PhotonNetwork.Time },
+            { JengaRoomProps.KEY_DURATION,   (double)gameTime }
+        });
+
             StartGame();
         }
     }
@@ -267,19 +298,8 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
         // 모든 클라이언트에게 카운트다운 완료 알림
         JengaNetworkManager.Instance?.BroadcastCountdownComplete();
 
-        // 마스터: 시작시각/지속시간을 룸 프로퍼티에 기록
-        if (PhotonNetwork.IsMasterClient)
-        {
-            var props = new Hashtable
-        {
-            { JengaRoomProps.KEY_START_TIME, PhotonNetwork.Time },   // 절대 동기 시간
-            { JengaRoomProps.KEY_DURATION,   (double)gameTime }      // seconds (double로 통일)
-        };
-            PhotonNetwork.CurrentRoom.SetCustomProperties(props);
-        }
-
-        // 타이머 시작
-        StartCoroutine(GameTimer());
+        ApplyGameStateChange(JengaGameState.Playing);
+        JengaNetworkManager.Instance?.BroadcastGameState(JengaGameState.Playing);
     }
 
     // 룸 프로퍼티(START_TIME, DURATION)로부터 남은 시간을 재계산해 UI에 반영
@@ -289,13 +309,39 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
         _roomStartTime = startTime;
         _roomDuration = durationSec;
 
-        var remain = Mathf.Max(0f, (float)((startTime + durationSec) - PhotonNetwork.Time));
+        double now = PhotonNetwork.Time;
+        double elapsed = Math.Max(0.0, now - startTime); // 시작 전이면 0으로 고정
+        remainingTime = Mathf.Max(0f, (float)(_roomDuration.Value - elapsed));
 
-        remainingTime = (float)remain;
         OnTimeUpdated?.Invoke(remainingTime);
-
         TryStartRoomPropTimer();
     }
+
+    // ROOM PROPS 미수신 시 재조회
+    private IEnumerator GameTimerWatchdog()
+    {
+        float probe = 0f;
+        while (currentState == JengaGameState.Playing && (!_roomStartTime.HasValue || !_roomDuration.HasValue))
+        {
+            probe += Time.unscaledDeltaTime;
+            if (probe > 3f)
+            {
+                var table = PhotonNetwork.CurrentRoom?.CustomProperties;
+                if (table != null &&
+                    JengaRoomProps.TryGet<double>(table, JengaRoomProps.KEY_START_TIME, out var st) &&
+                    JengaRoomProps.TryGet<double>(table, JengaRoomProps.KEY_DURATION, out var du))
+                {
+                    ApplySyncedTimerFromRoomProps(st, du);
+                    TryStartRoomPropTimer();
+                    yield break;
+                }
+                Debug.LogWarning("[JengaTimer] start/dur not set yet. Waiting...");
+                probe = 0f;
+            }
+            yield return null;
+        }
+    }
+
 
     #endregion
 
@@ -304,13 +350,15 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
     /// </summary>
     public void ApplyGameStateChange(JengaGameState newState)
     {
+        if (currentState == newState) return;
+
         currentState = newState;
         OnGameStateChanged?.Invoke(currentState);
 
         // 마스터: 게임 상태를 룸 프로퍼티로도 기록
         if (PhotonNetwork.IsMasterClient && PhotonNetwork.InRoom)
         {
-            var props = new Hashtable { { JengaRoomProps.KEY_STATE, (byte)currentState } };
+            var props = new Hashtable { { JengaRoomProps.KEY_STATE, (int)currentState } };
             PhotonNetwork.CurrentRoom.SetCustomProperties(props);
         }
 
@@ -322,6 +370,9 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
                 _endGameLock?.Dispose();
                 _endGameLock = null;
                 TryStartRoomPropTimer();
+
+                if (_timerWatchdog != null) StopCoroutine(_timerWatchdog);
+                _timerWatchdog = StartCoroutine(GameTimerWatchdog());
                 break;
 
             case JengaGameState.Finished:
@@ -333,6 +384,7 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
                     );
 
                 StopRoomPropTimer();
+                if (_timerWatchdog != null) { StopCoroutine(_timerWatchdog); _timerWatchdog = null; }
                 JengaUIManager.Instance.HideRotateButton();
                 break;
         }
@@ -569,6 +621,22 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
         if (currentState != JengaGameState.Playing) return;
         if (!_roomStartTime.HasValue || !_roomDuration.HasValue) return;
         if (_timerCo != null) return;               // 이미 돌고 있으면 스킵
+
+
+        if (PhotonNetwork.Time < _roomStartTime.Value)
+        {
+            // 아직 시작시각 전 -> 먼저 기다렸다가 시작
+            _timerCo = StartCoroutine(CoWaitUntilStartThenRun());
+            return;
+        }
+
+        _timerCo = StartCoroutine(GameTimer());
+    }
+
+    private IEnumerator CoWaitUntilStartThenRun()
+    {
+        while (PhotonNetwork.Time < _roomStartTime.Value)
+            yield return null;
         _timerCo = StartCoroutine(GameTimer());
     }
 
@@ -774,7 +842,7 @@ public class JengaGameManager : CombinedSingleton<JengaGameManager>, IGameCompon
         }
 
         // 3. 룸 프로퍼티에서 젠가 관련 데이터 제거 (다음 게임을 위해)
-        if (PhotonNetwork.InRoom)
+        if (PhotonNetwork.IsMasterClient && PhotonNetwork.InRoom && currentState == JengaGameState.Finished)
         {
             var clearProps = new Hashtable
             {

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaNetwork/JengaNetworkManager.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaNetwork/JengaNetworkManager.cs
@@ -119,7 +119,7 @@ public class JengaNetworkManager : PunSingleton<JengaNetworkManager>, IGameCompo
         }
         Debug.Log($"[JengaNetwork] Sending RPC to change state to: {state}");
 
-        thisPhotonView.RPC(nameof(RPC_ApplyGameState), RpcTarget.All, (int)state);
+        thisPhotonView.RPC(nameof(RPC_ApplyGameState), RpcTarget.Others, (int)state);
     }
 
     [PunRPC]
@@ -688,6 +688,23 @@ public class JengaNetworkManager : PunSingleton<JengaNetworkManager>, IGameCompo
 
     public override void OnRoomPropertiesUpdate(PhotonHashtable props)
     {
+        // START/DUR 적용
+        if (props.TryGetValue(JengaRoomProps.KEY_START_TIME, out var startObj) &&
+            props.TryGetValue(JengaRoomProps.KEY_DURATION, out var durObj) &&
+            startObj is double st && durObj is double du)
+        {
+            JengaGameManager.Instance?.ApplySyncedTimerFromRoomProps(st, du);
+        }
+
+        // STATE 적용
+        if (props.TryGetValue(JengaRoomProps.KEY_STATE, out var stateObj) && stateObj is int si)
+        {
+            if (JengaGameManager.Instance?.currentState != (JengaGameState)si)
+            {
+                JengaGameManager.Instance?.ApplyGameStateChange((JengaGameState)si);
+            }
+        }
+
         if (_receivedRankOnce) return;
 
         if (props.TryGetValue(JengaRoomProps.KEY_RANK_UIDS, out var uObj) &&

--- a/Assets/LTH/LTH_Scripts/Ranks/RankingRow.cs
+++ b/Assets/LTH/LTH_Scripts/Ranks/RankingRow.cs
@@ -164,7 +164,7 @@ public class RankingRow : MonoBehaviour
     public void EmphasizeFirstPlace()
     {
         KillFx();
-        if (cg) cg.alpha = 0f;
+        if (cg) cg.alpha = 1f;
 
         fxRoot.localScale = Vector3.one * _fxBaseScale;
         _punchTween = fxRoot.DOPunchScale(Vector3.one * punchScale, punchDuration, 10, 0.9f);

--- a/Assets/Scenes/MiniGameJengaScene.unity
+++ b/Assets/Scenes/MiniGameJengaScene.unity
@@ -122,6 +122,86 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &20052845
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 201037551}
+    m_Modifications:
+    - target: {fileID: 5651446509498788021, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_Name
+      value: Star (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 72.707146
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -68.01936
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -183.90341
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9313001
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.36425287
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -42.723
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7120867635128088013, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: -5801228030656462994, guid: 879532fb680028b48a18fd30681c81c0,
+        type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9cfa9c37b98744a449e7c0127f470a30, type: 3}
+--- !u!4 &20052846 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+    type: 3}
+  m_PrefabInstance: {fileID: 20052845}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &27118689
 GameObject:
   m_ObjectHideFlags: 0
@@ -257,6 +337,46 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 27118689}
   m_CullTransparentMesh: 1
+--- !u!21 &27643673
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 0.99999994, a: 1}
+    - _WidthHeightRadius: {r: 1275.0493, g: 849.3999, b: 80, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1 &29469105
 GameObject:
   m_ObjectHideFlags: 0
@@ -392,49 +512,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 29469105}
   m_CullTransparentMesh: 1
---- !u!1 &33146208
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 33146209}
-  m_Layer: 0
-  m_Name: 2P
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &33146209
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 33146208}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -28.457148, y: 38.12265, z: 28.653414}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 782016122}
-  - {fileID: 2026746949}
-  - {fileID: 2101809643}
-  - {fileID: 1130856794}
-  - {fileID: 1242796679}
-  - {fileID: 341978548}
-  - {fileID: 2028523226}
-  - {fileID: 482523131}
-  - {fileID: 142269116}
-  - {fileID: 1198879342}
-  - {fileID: 313445392}
-  - {fileID: 1361621135}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &39184139
 GameObject:
   m_ObjectHideFlags: 0
@@ -466,6 +543,96 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &110960463
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 201037551}
+    m_Modifications:
+    - target: {fileID: 329657563048967457, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: -5801228030656462994, guid: 879532fb680028b48a18fd30681c81c0,
+        type: 3}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.44314995
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.44315004
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 28.955816
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -37.92992
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -36.122665
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.93779
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.2384999
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.24693131
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.05189126
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -24.942
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -32.553
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 13.724
+      objectReference: {fileID: 0}
+    - target: {fileID: 6411628229678914976, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_Name
+      value: Star (5)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3c00ec95b49c1d546a217a587c86b37e, type: 3}
+--- !u!4 &110960464 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+    type: 3}
+  m_PrefabInstance: {fileID: 110960463}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &116948897
 GameObject:
   m_ObjectHideFlags: 0
@@ -722,96 +889,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 132400450}
   m_CullTransparentMesh: 1
---- !u!1001 &142269115
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 33146209}
-    m_Modifications:
-    - target: {fileID: 329657563048967457, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: -5801228030656462994, guid: 879532fb680028b48a18fd30681c81c0,
-        type: 3}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.44314992
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.44315007
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -37.93695
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -36.929886
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -65.525635
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.947194
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.23615153
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.2079633
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.06170368
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -24.942
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -27.815
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 13.724
-      objectReference: {fileID: 0}
-    - target: {fileID: 6411628229678914976, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_Name
-      value: Star (3)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 3c00ec95b49c1d546a217a587c86b37e, type: 3}
---- !u!4 &142269116 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-    type: 3}
-  m_PrefabInstance: {fileID: 142269115}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &151252677
 GameObject:
   m_ObjectHideFlags: 0
@@ -856,107 +933,50 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &197854449
-PrefabInstance:
+--- !u!1 &201037550
+GameObject:
   m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1368305595}
-    m_Modifications:
-    - target: {fileID: 100539952889884493, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 205163206283e7a40838be91cdc4eee7, type: 2}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.43432018
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.43431994
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -230.71503
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -35.62355
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -188.30173
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.96357924
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.09513574
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.24968626
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.0110019585
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -10.244
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -29.413
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 4.004
-      objectReference: {fileID: 0}
-    - target: {fileID: 5405934403816150963, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5405934403816150963, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
-    - target: {fileID: 7581750188737525860, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_Name
-      value: cloud_medium (6)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 7186054671757280169, guid: 03e21b53685994d43a092c2d1b9c6a84, type: 3}
-    - {fileID: 7084152554214074933, guid: 03e21b53685994d43a092c2d1b9c6a84, type: 3}
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 03e21b53685994d43a092c2d1b9c6a84, type: 3}
---- !u!4 &197854450 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-    type: 3}
-  m_PrefabInstance: {fileID: 197854449}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 201037551}
+  m_Layer: 0
+  m_Name: 2P
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &201037551
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 201037550}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -31.727148, y: 37.963623, z: 38.393406}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 371573363}
+  - {fileID: 415344789}
+  - {fileID: 1992865382}
+  - {fileID: 1378479454}
+  - {fileID: 20052846}
+  - {fileID: 110960464}
+  - {fileID: 916606202}
+  - {fileID: 1608619356}
+  - {fileID: 920006575}
+  - {fileID: 1616517817}
+  - {fileID: 393201831}
+  - {fileID: 218929758}
+  - {fileID: 1522635647}
+  m_Father: {fileID: 1110847946}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &201836500
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1115,6 +1135,200 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 201836500}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &218929757
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 201037551}
+    m_Modifications:
+    - target: {fileID: 205199232430197985, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 1462aa91d4f61ba4cbce45f1466e7370, type: 2}
+    - target: {fileID: 693171626104918311, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 949525825426924918, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140083441428025614, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1203845097954375624, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1601048368097342954, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 34.973694
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -38.12815
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -36.690258
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.8411365
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.030746298
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.53780264
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.048088007
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -5.938
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -65.045
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -2.756
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341286143228779244, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3457535365598932673, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4059265812233729036, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4091603727724860672, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Name
+      value: CH004_Jeomboon_ST000
+      objectReference: {fileID: 0}
+    - target: {fileID: 4091603727724860672, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4110911525456033966, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4235584798692782408, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4311174686238707878, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Avatar
+      value: 
+      objectReference: {fileID: 9000000, guid: 1accc64b5557f4d4d907b94256d3901d, type: 3}
+    - target: {fileID: 4311174686238707878, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: 7870b3e7bb5457944a99ec759d3caddc, type: 2}
+    - target: {fileID: 4323501119090150739, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4340203541418652595, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 1f009e6c9b3c12c4c90286f8520eeb3e, type: 2}
+    - target: {fileID: 4342870901537235461, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5871282379063428266, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5919040412902176434, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6011502035705782187, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6484597149563290023, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6982086428817300633, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7574369119542141112, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8244057176046662537, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e877e31156c607e46a5319bffdd8e6a6, type: 3}
+--- !u!4 &218929758 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+    type: 3}
+  m_PrefabInstance: {fileID: 218929757}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &231174369
 GameObject:
   m_ObjectHideFlags: 0
@@ -1248,6 +1462,96 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 231174369}
   m_CullTransparentMesh: 1
+--- !u!1001 &240813964
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 669275690}
+    m_Modifications:
+    - target: {fileID: 329657563048967457, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: -5801228030656462994, guid: 879532fb680028b48a18fd30681c81c0,
+        type: 3}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.44314995
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.44315004
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 28.955816
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -37.92992
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -36.122665
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.93779
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.2384999
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.24693131
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.05189126
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -24.942
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -32.553
+      objectReference: {fileID: 0}
+    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 13.724
+      objectReference: {fileID: 0}
+    - target: {fileID: 6411628229678914976, guid: 3c00ec95b49c1d546a217a587c86b37e,
+        type: 3}
+      propertyPath: m_Name
+      value: Star (5)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3c00ec95b49c1d546a217a587c86b37e, type: 3}
+--- !u!4 &240813965 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+    type: 3}
+  m_PrefabInstance: {fileID: 240813964}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &244144261
 GameObject:
   m_ObjectHideFlags: 0
@@ -1383,86 +1687,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 244144261}
   m_CullTransparentMesh: 1
---- !u!1001 &253332375
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 344144929}
-    m_Modifications:
-    - target: {fileID: 5651446509498788021, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_Name
-      value: Star (5)
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -109.78956
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -67.01933
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -274.9146
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.9455583
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.32545283
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -37.986
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7120867635128088013, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: -5801228030656462994, guid: 879532fb680028b48a18fd30681c81c0,
-        type: 3}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9cfa9c37b98744a449e7c0127f470a30, type: 3}
---- !u!4 &253332376 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-    type: 3}
-  m_PrefabInstance: {fileID: 253332375}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &254962752
 GameObject:
   m_ObjectHideFlags: 0
@@ -1556,200 +1780,6 @@ MonoBehaviour:
   compensateLetterbox: 1
   ignoreClicksOutsideDraw: 1
   rayDistance: 100
---- !u!1001 &262348055
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 344144929}
-    m_Modifications:
-    - target: {fileID: 205199232430197985, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 1462aa91d4f61ba4cbce45f1466e7370, type: 2}
-    - target: {fileID: 693171626104918311, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 949525825426924918, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1140083441428025614, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1203845097954375624, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1601048368097342954, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -135.23645
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -37.128113
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -125.08807
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.86264426
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.032707438
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.5025806
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.046776246
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -5.938
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -60.308
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -2.756
-      objectReference: {fileID: 0}
-    - target: {fileID: 3341286143228779244, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3457535365598932673, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4059265812233729036, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4091603727724860672, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Name
-      value: CH004_Jeomboon_ST000 (3)
-      objectReference: {fileID: 0}
-    - target: {fileID: 4091603727724860672, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110911525456033966, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4235584798692782408, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4311174686238707878, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Avatar
-      value: 
-      objectReference: {fileID: 9000000, guid: 1accc64b5557f4d4d907b94256d3901d, type: 3}
-    - target: {fileID: 4311174686238707878, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 9100000, guid: 7870b3e7bb5457944a99ec759d3caddc, type: 2}
-    - target: {fileID: 4323501119090150739, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4340203541418652595, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 1f009e6c9b3c12c4c90286f8520eeb3e, type: 2}
-    - target: {fileID: 4342870901537235461, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5871282379063428266, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5919040412902176434, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6011502035705782187, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6484597149563290023, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6982086428817300633, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7574369119542141112, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8244057176046662537, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e877e31156c607e46a5319bffdd8e6a6, type: 3}
---- !u!4 &262348056 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-    type: 3}
-  m_PrefabInstance: {fileID: 262348055}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &290534251
 GameObject:
   m_ObjectHideFlags: 0
@@ -1795,107 +1825,37 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &313445391
-PrefabInstance:
+--- !u!1 &315647959
+GameObject:
   m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 33146209}
-    m_Modifications:
-    - target: {fileID: 100539952889884493, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 205163206283e7a40838be91cdc4eee7, type: 2}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.43432006
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.43431994
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -35.491364
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -35.62355
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -63.00775
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.96357924
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.09513574
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.24968626
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.0110019585
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -10.244
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -29.413
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 4.004
-      objectReference: {fileID: 0}
-    - target: {fileID: 5405934403816150963, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5405934403816150963, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
-    - target: {fileID: 7581750188737525860, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_Name
-      value: cloud_medium (1)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 7186054671757280169, guid: 03e21b53685994d43a092c2d1b9c6a84, type: 3}
-    - {fileID: 7084152554214074933, guid: 03e21b53685994d43a092c2d1b9c6a84, type: 3}
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 03e21b53685994d43a092c2d1b9c6a84, type: 3}
---- !u!4 &313445392 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-    type: 3}
-  m_PrefabInstance: {fileID: 313445391}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 315647960}
+  m_Layer: 0
+  m_Name: TowerAnchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &315647960
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 315647959}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.26, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1460646842}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &330585543
 GameObject:
   m_ObjectHideFlags: 0
@@ -1983,13 +1943,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 330585543}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.039529894, y: 0.95894593, z: -0.16587429, w: 0.2265963}
-  m_LocalPosition: {x: -264.84, y: 10.8, z: -152.4}
+  m_LocalRotation: {x: 0.046350844, y: 0.94876266, z: -0.16409896, w: 0.266031}
+  m_LocalPosition: {x: 24.74, y: 9.53, z: 26.58}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 19.636, y: 150.476, z: 0.039}
+  m_LocalEulerAnglesHint: {x: 19.636, y: 148.68, z: 0.039}
 --- !u!114 &330585547
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2068,211 +2028,7 @@ MonoBehaviour:
   m_CameraActivatedEvent:
     m_PersistentCalls:
       m_Calls: []
---- !u!1001 &341978547
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 33146209}
-    m_Modifications:
-    - target: {fileID: 479507496456824461, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 776784365096445319, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 998254667235688689, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1633060438778835276, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1693657314738859876, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2179198918834414145, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 1f009e6c9b3c12c4c90286f8520eeb3e, type: 2}
-    - target: {fileID: 2310601242580406089, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2512335187230525871, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2559005317696410539, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 1462aa91d4f61ba4cbce45f1466e7370, type: 2}
-    - target: {fileID: 3086694288264551852, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Name
-      value: CH004_Jeomboon_ST000 (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3086694288264551852, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3351456639516302159, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.7701901
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.7701901
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -37.142395
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -34.312622
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -71.45215
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.99767405
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.052666105
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.037266307
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.022001648
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -5.938
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 4.421
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -2.756
-      objectReference: {fileID: 0}
-    - target: {fileID: 4083934630649291340, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4525720165913689547, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Avatar
-      value: 
-      objectReference: {fileID: 9000000, guid: 1accc64b5557f4d4d907b94256d3901d, type: 3}
-    - target: {fileID: 4525720165913689547, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 9100000, guid: 7870b3e7bb5457944a99ec759d3caddc, type: 2}
-    - target: {fileID: 4529109235228563054, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5271256582412779233, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5276360353308076930, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316937281457807783, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5955275044844109399, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7608830386932149021, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7931025381836048110, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8296299598140844717, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8630629350457918488, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8731934752483395896, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0518a9970e535cd44b39e7070452963a, type: 3}
---- !u!4 &341978548 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-    type: 3}
-  m_PrefabInstance: {fileID: 341978547}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &344144928
+--- !u!1 &363694452
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2280,1059 +2036,36 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 344144929}
+  - component: {fileID: 363694453}
   m_Layer: 0
-  m_Name: 3P
+  m_Name: TowerAnchor
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &344144929
+--- !u!4 &363694453
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 344144928}
+  m_GameObject: {fileID: 363694452}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -28.457148, y: 38.12265, z: 28.653414}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1581396041}
-  - {fileID: 568232470}
-  - {fileID: 253332376}
-  - {fileID: 941031025}
-  - {fileID: 793384236}
-  - {fileID: 656484617}
-  - {fileID: 1588409008}
-  - {fileID: 262348056}
-  - {fileID: 1438362381}
-  - {fileID: 396221720}
-  - {fileID: 1704368446}
-  - {fileID: 1496346195}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &347552062
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1368305595}
-    m_Modifications:
-    - target: {fileID: 1270154686371258703, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LODs.Array.data[1].renderers.Array.data[0].renderer
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 1270154686371258703, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LODs.Array.data[2].renderers.Array.data[0].renderer
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 1750915842032796396, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_Name
-      value: cloud_1 (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 6212925581419042433, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: b68a64caca02cbc4ab4e9f6b88ed316d, type: 2}
-    - target: {fileID: 7511083320534682346, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -233.20343
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -37.81157
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -188.50699
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.62356305
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.7817731
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 102.846
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 9110504180177871159, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e, type: 3}
-    - {fileID: 2128102938237016118, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e, type: 3}
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 1750915842032796396, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 347552065}
-  m_SourcePrefab: {fileID: 100100000, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e, type: 3}
---- !u!4 &347552063 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-    type: 3}
-  m_PrefabInstance: {fileID: 347552062}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &347552064 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1750915842032796396, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-    type: 3}
-  m_PrefabInstance: {fileID: 347552062}
-  m_PrefabAsset: {fileID: 0}
---- !u!65 &347552065
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 347552064}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1.1, y: 1, z: 1.1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!1 &392257174
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 392257178}
-  - component: {fileID: 392257177}
-  - component: {fileID: 392257176}
-  - component: {fileID: 392257175}
-  m_Layer: 0
-  m_Name: CollapseCam
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!114 &392257175
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 392257174}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 94a1a611ffc92aa47a85fe13856c093e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  cam: {fileID: 392257177}
-  targetRT: {fileID: 483322393}
-  rtSize: {x: 512, y: 512}
-  offset: {x: 0, y: 2.2, z: -3}
-  fov: 40
-  lookUpOffset: 0.3
---- !u!114 &392257176
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 392257174}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_RenderShadows: 1
-  m_RequiresDepthTextureOption: 2
-  m_RequiresOpaqueTextureOption: 2
-  m_CameraType: 0
-  m_Cameras: []
-  m_RendererIndex: -1
-  m_VolumeLayerMask:
-    serializedVersion: 2
-    m_Bits: 1
-  m_VolumeTrigger: {fileID: 0}
-  m_VolumeFrameworkUpdateModeOption: 2
-  m_RenderPostProcessing: 0
-  m_Antialiasing: 0
-  m_AntialiasingQuality: 2
-  m_StopNaN: 0
-  m_Dithering: 0
-  m_ClearDepth: 1
-  m_AllowXRRendering: 1
-  m_AllowHDROutput: 1
-  m_UseScreenCoordOverride: 0
-  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
-  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
-  m_RequiresDepthTexture: 0
-  m_RequiresColorTexture: 0
-  m_Version: 2
-  m_TaaSettings:
-    m_Quality: 3
-    m_FrameInfluence: 0.1
-    m_JitterScale: 1
-    m_MipBias: 0
-    m_VarianceClampScale: 0.9
-    m_ContrastAdaptiveSharpening: 0
---- !u!20 &392257177
-Camera:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 392257174}
-  m_Enabled: 0
-  serializedVersion: 2
-  m_ClearFlags: 2
-  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
-  m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
-  m_Iso: 200
-  m_ShutterSpeed: 0.005
-  m_Aperture: 16
-  m_FocusDistance: 10
-  m_FocalLength: 50
-  m_BladeCount: 5
-  m_Curvature: {x: 2, y: 11}
-  m_BarrelClipping: 0.25
-  m_Anamorphism: 0
-  m_SensorSize: {x: 36, y: 24}
-  m_LensShift: {x: 0, y: 0}
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: 0.3
-  far clip plane: 1000
-  field of view: 40
-  orthographic: 0
-  orthographic size: 5
-  m_Depth: 0
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 0
-  m_TargetEye: 3
-  m_HDR: 0
-  m_AllowMSAA: 0
-  m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 0
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
---- !u!4 &392257178
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 392257174}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 158.84209, y: 268.27615, z: -28.395874}
+  m_LocalPosition: {x: -0.26, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 1110847946}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &396221719
+--- !u!1001 &371573362
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 344144929}
-    m_Modifications:
-    - target: {fileID: 1528725312502566776, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1.1799998
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.1799996
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1.1799995
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -132.45532
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -27.125687
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -151.11322
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.99953806
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.016289156
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.022152629
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.012949174
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 1.833
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 2.564
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 1.525
-      objectReference: {fileID: 0}
-    - target: {fileID: 7349414926691905503, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_Name
-      value: cloud_medium (3)
-      objectReference: {fileID: 0}
-    - target: {fileID: 7859370079127710536, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 205163206283e7a40838be91cdc4eee7, type: 2}
-    m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 8737101222051999724, guid: 5afb8b4ced538e949ba0d67073aa9e5c, type: 3}
-    - {fileID: 506987933308232340, guid: 5afb8b4ced538e949ba0d67073aa9e5c, type: 3}
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 5afb8b4ced538e949ba0d67073aa9e5c, type: 3}
---- !u!4 &396221720 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-    type: 3}
-  m_PrefabInstance: {fileID: 396221719}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &407208379
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 407208380}
-  - component: {fileID: 407208383}
-  - component: {fileID: 407208382}
-  - component: {fileID: 407208381}
-  m_Layer: 5
-  m_Name: BottomPanel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &407208380
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 407208379}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 231174370}
-  m_Father: {fileID: 419628864}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0}
-  m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 0, y: 80.1582}
-  m_SizeDelta: {x: 1082, y: 160.317}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &407208381
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 407208379}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Padding:
-    m_Left: 0
-    m_Right: 0
-    m_Top: 0
-    m_Bottom: 0
-  m_ChildAlignment: 4
-  m_Spacing: 0
-  m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 1
-  m_ChildControlWidth: 0
-  m_ChildControlHeight: 0
-  m_ChildScaleWidth: 0
-  m_ChildScaleHeight: 0
-  m_ReverseArrangement: 0
---- !u!114 &407208382
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 407208379}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
-  m_RaycastTarget: 0
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 5f8f1c8354b9741f0921ae0eef8aa970, type: 3}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &407208383
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 407208379}
-  m_CullTransparentMesh: 1
---- !u!1 &410087039
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 410087041}
-  - component: {fileID: 410087040}
-  - component: {fileID: 410087042}
-  m_Layer: 0
-  m_Name: Directional Light
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!108 &410087040
-Light:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 410087039}
-  m_Enabled: 1
-  serializedVersion: 10
-  m_Type: 1
-  m_Shape: 0
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_Intensity: 2
-  m_Range: 10
-  m_SpotAngle: 30
-  m_InnerSpotAngle: 21.80208
-  m_CookieSize: 10
-  m_Shadows:
-    m_Type: 2
-    m_Resolution: -1
-    m_CustomResolution: -1
-    m_Strength: 1
-    m_Bias: 0.05
-    m_NormalBias: 0.4
-    m_NearPlane: 0.2
-    m_CullingMatrixOverride:
-      e00: 1
-      e01: 0
-      e02: 0
-      e03: 0
-      e10: 0
-      e11: 1
-      e12: 0
-      e13: 0
-      e20: 0
-      e21: 0
-      e22: 1
-      e23: 0
-      e30: 0
-      e31: 0
-      e32: 0
-      e33: 1
-    m_UseCullingMatrixOverride: 0
-  m_Cookie: {fileID: 0}
-  m_DrawHalo: 0
-  m_Flare: {fileID: 0}
-  m_RenderMode: 0
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingLayerMask: 1
-  m_Lightmapping: 4
-  m_LightShadowCasterMode: 0
-  m_AreaSize: {x: 1, y: 1}
-  m_BounceIntensity: 1
-  m_ColorTemperature: 5000
-  m_UseColorTemperature: 1
-  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
-  m_UseBoundingSphereOverride: 0
-  m_UseViewFrustumForShadowCasterCull: 1
-  m_ShadowRadius: 0
-  m_ShadowAngle: 0
---- !u!4 &410087041
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 410087039}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
-  m_LocalPosition: {x: 0, y: 3, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!114 &410087042
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 410087039}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Version: 3
-  m_UsePipelineSettings: 1
-  m_AdditionalLightsShadowResolutionTier: 2
-  m_LightLayerMask: 1
-  m_RenderingLayers: 1
-  m_CustomShadowLayers: 0
-  m_ShadowLayerMask: 1
-  m_ShadowRenderingLayers: 1
-  m_LightCookieSize: {x: 1, y: 1}
-  m_LightCookieOffset: {x: 0, y: 0}
-  m_SoftShadowQuality: 1
---- !u!1001 &419628863
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6885039544089571689, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_Name
-      value: Canvas
-      objectReference: {fileID: 0}
-    - target: {fileID: 6885039544089571689, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8510048701061075239, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      propertyPath: m_AdditionalShaderChannelsFlag
-      value: 25
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1648873810}
-    - targetCorrespondingSourceObject: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 938219810}
-    - targetCorrespondingSourceObject: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 132007708}
-    - targetCorrespondingSourceObject: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1934672920}
-    - targetCorrespondingSourceObject: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1375761813}
-    - targetCorrespondingSourceObject: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 407208380}
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b4f2cd633f84448609793082bcf66d70, type: 3}
---- !u!224 &419628864 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
-    type: 3}
-  m_PrefabInstance: {fileID: 419628863}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &482523130
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 33146209}
-    m_Modifications:
-    - target: {fileID: 205199232430197985, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 1462aa91d4f61ba4cbce45f1466e7370, type: 2}
-    - target: {fileID: 693171626104918311, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 949525825426924918, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1140083441428025614, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1203845097954375624, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1601048368097342954, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -31.986448
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -37.128113
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -66.58807
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.86264426
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.032707438
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.5025806
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.046776246
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -5.938
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -60.308
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -2.756
-      objectReference: {fileID: 0}
-    - target: {fileID: 3341286143228779244, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3457535365598932673, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4059265812233729036, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4091603727724860672, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Name
-      value: CH004_Jeomboon_ST000
-      objectReference: {fileID: 0}
-    - target: {fileID: 4091603727724860672, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110911525456033966, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4235584798692782408, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4311174686238707878, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Avatar
-      value: 
-      objectReference: {fileID: 9000000, guid: 1accc64b5557f4d4d907b94256d3901d, type: 3}
-    - target: {fileID: 4311174686238707878, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 9100000, guid: 7870b3e7bb5457944a99ec759d3caddc, type: 2}
-    - target: {fileID: 4323501119090150739, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4340203541418652595, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 1f009e6c9b3c12c4c90286f8520eeb3e, type: 2}
-    - target: {fileID: 4342870901537235461, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5871282379063428266, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5919040412902176434, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6011502035705782187, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6484597149563290023, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6982086428817300633, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7574369119542141112, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8244057176046662537, guid: e877e31156c607e46a5319bffdd8e6a6,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e877e31156c607e46a5319bffdd8e6a6, type: 3}
---- !u!4 &482523131 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
-    type: 3}
-  m_PrefabInstance: {fileID: 482523130}
-  m_PrefabAsset: {fileID: 0}
---- !u!84 &483322393
-RenderTexture:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_ImageContentsHash:
-    serializedVersion: 2
-    Hash: 00000000000000000000000000000000
-  m_ForcedFallbackFormat: 4
-  m_DownscaleFallback: 0
-  m_IsAlphaChannelOptional: 0
-  serializedVersion: 5
-  m_Width: 1024
-  m_Height: 1024
-  m_AntiAliasing: 1
-  m_MipCount: -1
-  m_DepthStencilFormat: 90
-  m_ColorFormat: 4
-  m_MipMap: 0
-  m_GenerateMips: 0
-  m_SRGB: 1
-  m_UseDynamicScale: 0
-  m_BindMS: 0
-  m_EnableCompatibleFormat: 1
-  m_EnableRandomWrite: 0
-  m_TextureSettings:
-    serializedVersion: 2
-    m_FilterMode: 1
-    m_Aniso: 0
-    m_MipBias: 0
-    m_WrapU: 1
-    m_WrapV: 1
-    m_WrapW: 1
-  m_Dimension: 2
-  m_VolumeDepth: 1
-  m_ShadowSamplingMode: 2
---- !u!1001 &487881567
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1368305595}
+    m_TransformParent: {fileID: 201037551}
     m_Modifications:
     - target: {fileID: 22155592255493168, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
@@ -3457,3678 +2190,23 @@ PrefabInstance:
     - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -230.8273
+      value: 31.457148
       objectReference: {fileID: 0}
     - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -36.852615
+      value: -37.85265
       objectReference: {fileID: 0}
     - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -192.95016
+      value: -38.053413
       objectReference: {fileID: 0}
     - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.9991457
-      objectReference: {fileID: 0}
-    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.041328084
-      objectReference: {fileID: 0}
-    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 4.737
-      objectReference: {fileID: 0}
-    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1340917988430205607, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1340917988430205607, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 1495097847972775850, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1495097847972775850, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 1596267127136250158, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1596267127136250158, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 1665415229873288315, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 1736378830458349675, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 1845784568966000089, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1845784568966000089, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 2038612119992206113, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 2076882152173295359, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 2153432934900547576, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 2155132447699492003, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 2308337712043047829, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 2375386941894113963, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 2404667205930070138, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 2406401350878136260, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2406401350878136260, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 2661396680078406401, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 2722753316705796921, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2722753316705796921, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 2771923637222776831, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2771923637222776831, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 2787308115362846088, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 2839867045486128883, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2839867045486128883, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 2885084885758892758, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885084885758892758, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 2887690281359775391, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2887690281359775391, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 2992135530745749749, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 3001849979441450719, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 3005727962097887924, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3005727962097887924, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 3041196279614361117, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3041196279614361117, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 3261009662981286812, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 3416674001866434362, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3416674001866434362, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 3505705461291080819, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3505705461291080819, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 3531231261470652379, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.0497
-      objectReference: {fileID: 0}
-    - target: {fileID: 3800455879800047648, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 3994959866047517518, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3994959866047517518, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 4140304655994197350, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4140304655994197350, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 4188343569351860611, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 4196060385186400686, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 4197595123226478936, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4197595123226478936, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 4339274808398475724, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4339274808398475724, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 4344405680525151917, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 4349141498655887898, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 4398894214655572765, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4398894214655572765, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 4464510989897335917, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 4832482362144014220, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4832482362144014220, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 4848909546885351958, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4848909546885351958, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 4896016000791029342, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4896016000791029342, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 5096764325150322401, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5096764325150322401, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 5116273792172264949, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5116273792172264949, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 5252997337185806556, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 5260347511967309562, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 5349660182146679502, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 5603477323529394169, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5603477323529394169, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 5808853389497651303, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 5817699679196710845, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5817699679196710845, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 6139898067430685923, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6139898067430685923, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 6210173168455794465, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6210173168455794465, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 6291494815040878487, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 6550029043274057131, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6550029043274057131, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 6601849725924175426, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6601849725924175426, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 6873858858885959258, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6873858858885959258, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 6887620469895559334, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 6917070216655512044, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6917070216655512044, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 6921410993619055940, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6921410993619055940, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 7014733665442605631, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7014733665442605631, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 7069958683730946128, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 7179605924460934488, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7179605924460934488, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 7293422265078263754, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7293422265078263754, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 7298045014559106539, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 7476504372083623875, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 7492815276572038720, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 7500020107541243142, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 7652479989106242777, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 7707041019526897873, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7707041019526897873, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 7910866339413639222, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7910866339413639222, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 8005340992367534437, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 8091382583360473318, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8091382583360473318, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 8290480986608609771, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8290480986608609771, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 8414897384260690424, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8414897384260690424, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 8568582946995555276, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 9020946318807993640, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 9064418881484696250, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Name
-      value: SM_Jenga_Tower_1 (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 9064418881484696250, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9087388445363831751, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 9163585210480661473, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9163585210480661473, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 870433e8f73f4f74ab76a6188d5fadef, type: 3}
---- !u!4 &487881568 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
-    type: 3}
-  m_PrefabInstance: {fileID: 487881567}
-  m_PrefabAsset: {fileID: 0}
---- !u!21 &510692240
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0.024052067, g: 0.022535274, b: 0.9789449, a: 0.9755116}
-    - _WidthHeightRadius: {r: 1192.5742, g: 319.42212, b: 80, a: 0}
-  m_BuildTextureStacks: []
---- !u!1 &545133229
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 545133231}
-  - component: {fileID: 545133230}
-  m_Layer: 0
-  m_Name: JengaPhotonViewCoordinator
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &545133230
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 545133229}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 48c2c32953764648bd684ac38a9d4b47, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  sceneViews: []
-  roots: []
---- !u!4 &545133231
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 545133229}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -4.654665, y: -5.1745243, z: 13.160173}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &568232469
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 344144929}
-    m_Modifications:
-    - target: {fileID: 2202635855084851171, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
-        type: 3}
-      propertyPath: m_Name
-      value: Star (4)
-      objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -74.86271
-      objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -39.019333
-      objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -207.6192
-      objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.9455583
-      objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.32545283
-      objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -37.986
-      objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4514368027778736621, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: -5801228030656462994, guid: 879532fb680028b48a18fd30681c81c0,
-        type: 3}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 43bf369892f7f7d4cb1dc7249773b8c7, type: 3}
---- !u!4 &568232470 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
-    type: 3}
-  m_PrefabInstance: {fileID: 568232469}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &580941682
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 580941683}
-  - component: {fileID: 580941685}
-  - component: {fileID: 580941684}
-  m_Layer: 5
-  m_Name: SelectionRect
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &580941683
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 580941682}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 254962753}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &580941684
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 580941682}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: d6e723ac92a5e1d4eb2e756bb613e140, type: 3}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &580941685
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 580941682}
-  m_CullTransparentMesh: 1
---- !u!1 &586440522
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 586440524}
-  - component: {fileID: 586440523}
-  m_Layer: 0
-  m_Name: JengaLocalCamreaBinder
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &586440523
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 586440522}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5bd94555db73ec84a845da430237c75c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  vcamPrefab: {fileID: 3382513035572775980, guid: c9cd8d7c7520074449b8b9e41941637a,
-    type: 3}
-  commonLayers:
-    serializedVersion: 2
-    m_Bits: 33
---- !u!4 &586440524
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 586440522}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 26.497707, y: -0.39967346, z: 7.6236916}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &656484616
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 344144929}
-    m_Modifications:
-    - target: {fileID: 479507496456824461, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 776784365096445319, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 998254667235688689, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1633060438778835276, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1693657314738859876, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2179198918834414145, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 1f009e6c9b3c12c4c90286f8520eeb3e, type: 2}
-    - target: {fileID: 2310601242580406089, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2512335187230525871, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2559005317696410539, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 1462aa91d4f61ba4cbce45f1466e7370, type: 2}
-    - target: {fileID: 3086694288264551852, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Name
-      value: CH004_Jeomboon_ST000 (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3086694288264551852, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3351456639516302159, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.7701902
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.7701902
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -140.3924
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -34.312622
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -129.95215
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.99767405
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.052666105
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.037266307
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.022001648
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -5.938
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 4.421
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -2.756
-      objectReference: {fileID: 0}
-    - target: {fileID: 4083934630649291340, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4525720165913689547, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Avatar
-      value: 
-      objectReference: {fileID: 9000000, guid: 1accc64b5557f4d4d907b94256d3901d, type: 3}
-    - target: {fileID: 4525720165913689547, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 9100000, guid: 7870b3e7bb5457944a99ec759d3caddc, type: 2}
-    - target: {fileID: 4529109235228563054, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5271256582412779233, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5276360353308076930, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316937281457807783, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5955275044844109399, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7608830386932149021, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7931025381836048110, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8296299598140844717, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8630629350457918488, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8731934752483395896, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0518a9970e535cd44b39e7070452963a, type: 3}
---- !u!4 &656484617 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-    type: 3}
-  m_PrefabInstance: {fileID: 656484616}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &717713850
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1368305595}
-    m_Modifications:
-    - target: {fileID: 1393713133580456719, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_Name
-      value: Star (11)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1523659555437022603, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: -5801228030656462994, guid: 879532fb680028b48a18fd30681c81c0,
-        type: 3}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -158.09381
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -19.519333
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -359.62622
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.9455583
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.32545283
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -37.986
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d, type: 3}
---- !u!4 &717713851 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-    type: 3}
-  m_PrefabInstance: {fileID: 717713850}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &748278359
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 562723092912506160, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -164.19
-      objectReference: {fileID: 0}
-    - target: {fileID: 562723092912506160, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.93
-      objectReference: {fileID: 0}
-    - target: {fileID: 562723092912506160, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -101.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 562723092912506160, guid: fe50d52b558578d43beb59995e9a9ca4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 562723092912506160, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 562723092912506160, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 562723092912506160, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 562723092912506160, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1463674121782452736, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -1.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 1463674121782452736, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.08
-      objectReference: {fileID: 0}
-    - target: {fileID: 2451782784813004358, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -1.25
-      objectReference: {fileID: 0}
-    - target: {fileID: 2703642404708267145, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -63.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 2703642404708267145, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.91
-      objectReference: {fileID: 0}
-    - target: {fileID: 2703642404708267145, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -42.21
-      objectReference: {fileID: 0}
-    - target: {fileID: 2703642404708267145, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2703642404708267145, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2703642404708267145, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2703642404708267145, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2703642404708267145, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2859464421426194495, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 30.51
-      objectReference: {fileID: 0}
-    - target: {fileID: 2859464421426194495, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.14
-      objectReference: {fileID: 0}
-    - target: {fileID: 2859464421426194495, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 12.88
-      objectReference: {fileID: 0}
-    - target: {fileID: 2859464421426194495, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2859464421426194495, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2859464421426194495, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2859464421426194495, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2859464421426194495, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3226987432599523960, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3879852811759145387, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4550220700672617421, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4625638008536974983, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -6.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 4701654860940241262, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -4.83
-      objectReference: {fileID: 0}
-    - target: {fileID: 4701654860940241262, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.12
-      objectReference: {fileID: 0}
-    - target: {fileID: 6141946945002473970, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -4.73
-      objectReference: {fileID: 0}
-    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.63
-      objectReference: {fileID: 0}
-    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.23845437
-      objectReference: {fileID: 0}
-    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7500476990348501097, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7830282080685953408, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -3.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 7830282080685953408, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997442498939513690, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -255.37
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997442498939513690, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.01
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997442498939513690, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -167.45
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997442498939513690, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997442498939513690, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997442498939513690, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997442498939513690, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997442498939513690, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8068020423338431611, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8280847053682877144, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8435625876723763533, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8466552122991562632, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9043512953739879483, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_Name
-      value: JengaTowerManager
-      objectReference: {fileID: 0}
-    - target: {fileID: 9152528478550071037, guid: fe50d52b558578d43beb59995e9a9ca4,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -3.58
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 3226987432599523960, guid: fe50d52b558578d43beb59995e9a9ca4, type: 3}
-    - {fileID: 8068020423338431611, guid: fe50d52b558578d43beb59995e9a9ca4, type: 3}
-    - {fileID: 4550220700672617421, guid: fe50d52b558578d43beb59995e9a9ca4, type: 3}
-    - {fileID: 7500476990348501097, guid: fe50d52b558578d43beb59995e9a9ca4, type: 3}
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: fe50d52b558578d43beb59995e9a9ca4, type: 3}
---- !u!1 &760830003
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 760830004}
-  - component: {fileID: 760830006}
-  - component: {fileID: 760830005}
-  m_Layer: 5
-  m_Name: OverlayRoot
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &760830004
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 760830003}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1637472400}
-  - {fileID: 875495119}
-  m_Father: {fileID: 201836501}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!225 &760830005
-CanvasGroup:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 760830003}
-  m_Enabled: 1
-  m_Alpha: 0
-  m_Interactable: 0
-  m_BlocksRaycasts: 0
-  m_IgnoreParentGroups: 0
---- !u!114 &760830006
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 760830003}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f6f614f7bd59cd640bf929365a2bfa66, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  group: {fileID: 760830005}
-  preview: {fileID: 254962754}
-  okButton: {fileID: 1535448053}
-  backdrop: {fileID: 1637472401}
-  towerCam: {fileID: 2139196078}
-  useOrthographic: 1
-  padding: 1.3
-  orthoCamDist: 3
-  slightTiltDeg: 0
-  layerWidth: 3
-  layerHeightMultiplier: 2
-  zoomFactor: 0.7
-  worldFrontBasis: {fileID: 0}
-  invertWorldFront: 0
-  arenaMask:
-    serializedVersion: 2
-    m_Bits: 30720
---- !u!1 &778023254
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 778023255}
-  m_Layer: 0
-  m_Name: ---------Bootstrap------
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &778023255
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 778023254}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 24.953793, y: -12.302406, z: -145.06204}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &778223936
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 778223937}
-  m_Layer: 0
-  m_Name: -------------------------
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &778223937
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 778223936}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 306.63657, y: 1225.811, z: -3.3471224}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 956063945}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &782016121
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 33146209}
-    m_Modifications:
-    - target: {fileID: 614895130769055622, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
-    - target: {fileID: 4603879714568064926, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: d7cd310ef634a034abab2d9806894dc9, type: 2}
-    - target: {fileID: 5066022526432343303, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.26985377
-      objectReference: {fileID: 0}
-    - target: {fileID: 5066022526432343303, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5066022526432343303, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.48957014
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -37.30606
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -34.87262
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -70.81067
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.061361626
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.99811566
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -172.964
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6508736201795955369, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_Name
-      value: cloud_small (2)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 3807266887916899018, guid: 14d72a544b3ee7e49a3e59a75ff170ec, type: 3}
-    - {fileID: 1027792874845127237, guid: 14d72a544b3ee7e49a3e59a75ff170ec, type: 3}
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 14d72a544b3ee7e49a3e59a75ff170ec, type: 3}
---- !u!4 &782016122 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-    type: 3}
-  m_PrefabInstance: {fileID: 782016121}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &793384235
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 344144929}
-    m_Modifications:
-    - target: {fileID: 1393713133580456719, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_Name
-      value: Star (6)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1523659555437022603, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: -5801228030656462994, guid: 879532fb680028b48a18fd30681c81c0,
-        type: 3}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -66.12014
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -19.519333
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -292.83228
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.9455583
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.32545283
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -37.986
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d, type: 3}
---- !u!4 &793384236 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-    type: 3}
-  m_PrefabInstance: {fileID: 793384235}
-  m_PrefabAsset: {fileID: 0}
---- !u!21 &794713411
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 0.99999994, a: 1}
-    - _WidthHeightRadius: {r: 1275.0493, g: 849.3999, b: 80, a: 0}
-  m_BuildTextureStacks: []
---- !u!1 &832575517
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 832575519}
-  - component: {fileID: 832575518}
-  m_Layer: 0
-  m_Name: Global Volume
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &832575518
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 832575517}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 172515602e62fb746b5d573b38a5fe58, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IsGlobal: 1
-  priority: 0
-  blendDistance: 0
-  weight: 1
-  sharedProfile: {fileID: 11400000, guid: a6560a915ef98420e9faacc1c7438823, type: 2}
---- !u!4 &832575519
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 832575517}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &835420898
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 835420899}
-  - component: {fileID: 835420902}
-  - component: {fileID: 835420901}
-  - component: {fileID: 835420900}
-  m_Layer: 5
-  m_Name: Timer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &835420899
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 835420898}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 3.5999994, y: 3.5999994, z: 3.5999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 29469106}
-  - {fileID: 1867122146}
-  m_Father: {fileID: 1934672920}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 149.651, y: 51.939}
-  m_Pivot: {x: 0.5, y: 1}
---- !u!114 &835420900
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 835420898}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: adb30198aa32dd140b5750692dd48104, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  radius: 20
-  image: {fileID: 835420901}
---- !u!114 &835420901
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 835420898}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 1770409293}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 24160931ebfa44f2f8c9452c96dacd00, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &835420902
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 835420898}
-  m_CullTransparentMesh: 1
---- !u!1001 &872848296
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 116.216644
-      objectReference: {fileID: 0}
-    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 130.18143
-      objectReference: {fileID: 0}
-    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 11.598944
-      objectReference: {fileID: 0}
-    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1620587405723649436, guid: f00d8d7cec95f9f44a648ba384285527,
-        type: 3}
-      propertyPath: m_Name
-      value: JengaTimingManager
-      objectReference: {fileID: 0}
-    - target: {fileID: 2658409117490003364, guid: f00d8d7cec95f9f44a648ba384285527,
-        type: 3}
-      propertyPath: timingUI
-      value: 
-      objectReference: {fileID: 1804809742}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f00d8d7cec95f9f44a648ba384285527, type: 3}
---- !u!1 &875495118
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 875495119}
-  - component: {fileID: 875495121}
-  - component: {fileID: 875495120}
-  m_Layer: 5
-  m_Name: TowerFocusOverlayPanel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &875495119
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 875495118}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 254962753}
-  - {fileID: 1535448052}
-  m_Father: {fileID: 760830004}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0}
-  m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 0.00024414062, y: -283.57782}
-  m_SizeDelta: {x: 1080, y: 795.86414}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &875495120
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 875495118}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 87ff1ad01a5c8a24286a1dc24db49657, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &875495121
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 875495118}
-  m_CullTransparentMesh: 1
---- !u!1 &883198816
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 883198817}
-  m_Layer: 0
-  m_Name: ------------UI----------------
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &883198817
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 883198816}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 116.216644, y: 130.18143, z: 11.598944}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &891583929
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1368305595}
-    m_Modifications:
-    - target: {fileID: 479507496456824461, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 776784365096445319, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 998254667235688689, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1633060438778835276, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1693657314738859876, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2179198918834414145, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 1f009e6c9b3c12c4c90286f8520eeb3e, type: 2}
-    - target: {fileID: 2310601242580406089, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2512335187230525871, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2559005317696410539, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 1462aa91d4f61ba4cbce45f1466e7370, type: 2}
-    - target: {fileID: 3086694288264551852, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Name
-      value: CH004_Jeomboon_ST000 (5)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3086694288264551852, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3351456639516302159, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.77019024
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.77019024
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -232.36606
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -34.312622
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -196.74612
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.99767405
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.052666105
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.037266307
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.022001648
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -5.938
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 4.421
-      objectReference: {fileID: 0}
-    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -2.756
-      objectReference: {fileID: 0}
-    - target: {fileID: 4083934630649291340, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4525720165913689547, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Avatar
-      value: 
-      objectReference: {fileID: 9000000, guid: 1accc64b5557f4d4d907b94256d3901d, type: 3}
-    - target: {fileID: 4525720165913689547, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 9100000, guid: 7870b3e7bb5457944a99ec759d3caddc, type: 2}
-    - target: {fileID: 4529109235228563054, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5271256582412779233, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5276360353308076930, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5316937281457807783, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5955275044844109399, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7608830386932149021, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7931025381836048110, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8296299598140844717, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8630629350457918488, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8731934752483395896, guid: 0518a9970e535cd44b39e7070452963a,
-        type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0518a9970e535cd44b39e7070452963a, type: 3}
---- !u!4 &891583930 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
-    type: 3}
-  m_PrefabInstance: {fileID: 891583929}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &893449271
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 893449274}
-  - component: {fileID: 893449273}
-  - component: {fileID: 893449272}
-  m_Layer: 0
-  m_Name: EventSystem
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &893449272
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 893449271}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_SendPointerHoverToParent: 1
-  m_MoveRepeatDelay: 0.5
-  m_MoveRepeatRate: 0.1
-  m_XRTrackingOrigin: {fileID: 0}
-  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018,
-    type: 3}
-  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018,
-    type: 3}
-  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018,
-    type: 3}
-  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018,
-    type: 3}
-  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018,
-    type: 3}
-  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018,
-    type: 3}
-  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018,
-    type: 3}
-  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018,
-    type: 3}
-  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018,
-    type: 3}
-  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018,
-    type: 3}
-  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018,
-    type: 3}
-  m_DeselectOnBackgroundClick: 1
-  m_PointerBehavior: 1
-  m_CursorLockBehavior: 0
-  m_ScrollDeltaPerTick: 6
---- !u!114 &893449273
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 893449271}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
---- !u!4 &893449274
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 893449271}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &938219809
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 938219810}
-  - component: {fileID: 938219812}
-  - component: {fileID: 938219811}
-  m_Layer: 5
-  m_Name: CountDownPanel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &938219810
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 938219809}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1932304811}
-  m_Father: {fileID: 419628864}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 24, y: 125.061005}
-  m_SizeDelta: {x: 700.454, y: 948.578}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &938219811
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 938219809}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 1
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &938219812
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 938219809}
-  m_CullTransparentMesh: 1
---- !u!1001 &941031024
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 344144929}
-    m_Modifications:
-    - target: {fileID: 1270154686371258703, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LODs.Array.data[1].renderers.Array.data[0].renderer
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 1270154686371258703, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LODs.Array.data[2].renderers.Array.data[0].renderer
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 1750915842032796396, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_Name
-      value: cloud_1 (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 6212925581419042433, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: b68a64caca02cbc4ab4e9f6b88ed316d, type: 2}
-    - target: {fileID: 7511083320534682346, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -141.22977
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -37.81157
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -121.71301
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.62356305
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.7817731
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 102.846
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 9110504180177871159, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e, type: 3}
-    - {fileID: 2128102938237016118, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e, type: 3}
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 1750915842032796396, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 941031027}
-  m_SourcePrefab: {fileID: 100100000, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e, type: 3}
---- !u!4 &941031025 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-    type: 3}
-  m_PrefabInstance: {fileID: 941031024}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &941031026 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1750915842032796396, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-    type: 3}
-  m_PrefabInstance: {fileID: 941031024}
-  m_PrefabAsset: {fileID: 0}
---- !u!65 &941031027
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 941031026}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1.1, y: 1, z: 1.1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!1 &956063944
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 956063945}
-  - component: {fileID: 956063946}
-  m_Layer: 0
-  m_Name: JengaInputBootstrap
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &956063945
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 956063944}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -315.07175, y: -1221.0004, z: -8.96214}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 778223937}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &956063946
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 956063944}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 77614f6bab3a323429abffcfea60a8c3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &984699242
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 984699243}
-  - component: {fileID: 984699245}
-  - component: {fileID: 984699244}
-  m_Layer: 5
-  m_Name: Content
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &984699243
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 984699242}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1648873810}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 0.000015258789, y: -35.64461}
-  m_SizeDelta: {x: 49.13, y: 0}
-  m_Pivot: {x: 0, y: 1}
---- !u!114 &984699244
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 984699242}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalFit: 0
-  m_VerticalFit: 2
---- !u!114 &984699245
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 984699242}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Padding:
-    m_Left: 0
-    m_Right: 0
-    m_Top: 0
-    m_Bottom: 0
-  m_ChildAlignment: 1
-  m_Spacing: 10
-  m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 0
-  m_ChildControlWidth: 1
-  m_ChildControlHeight: 1
-  m_ChildScaleWidth: 0
-  m_ChildScaleHeight: 0
-  m_ReverseArrangement: 0
---- !u!1 &993787422
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 993787423}
-  m_Layer: 0
-  m_Name: ----------Controller------------
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &993787423
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 993787422}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 7.5236197, y: 5.509158, z: 5.135033}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1130856793
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 33146209}
-    m_Modifications:
-    - target: {fileID: 1270154686371258703, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LODs.Array.data[1].renderers.Array.data[0].renderer
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 1270154686371258703, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LODs.Array.data[2].renderers.Array.data[0].renderer
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 1750915842032796396, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_Name
-      value: cloud_1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6212925581419042433, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: b68a64caca02cbc4ab4e9f6b88ed316d, type: 2}
-    - target: {fileID: 7511083320534682346, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -37.979767
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -37.81157
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -63.213013
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.62356305
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.7817731
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 102.846
-      objectReference: {fileID: 0}
-    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 9110504180177871159, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e, type: 3}
-    - {fileID: 2128102938237016118, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e, type: 3}
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 1750915842032796396, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1130856796}
-  m_SourcePrefab: {fileID: 100100000, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e, type: 3}
---- !u!4 &1130856794 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-    type: 3}
-  m_PrefabInstance: {fileID: 1130856793}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1130856795 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1750915842032796396, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
-    type: 3}
-  m_PrefabInstance: {fileID: 1130856793}
-  m_PrefabAsset: {fileID: 0}
---- !u!65 &1130856796
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1130856795}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1.1, y: 1, z: 1.1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!1001 &1191726037
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1368305595}
-    m_Modifications:
-    - target: {fileID: 5651446509498788021, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_Name
-      value: Star (10)
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -201.76321
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -67.01933
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -341.70856
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.9455583
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.32545283
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -37.986
-      objectReference: {fileID: 0}
-    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7120867635128088013, guid: 9cfa9c37b98744a449e7c0127f470a30,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: -5801228030656462994, guid: 879532fb680028b48a18fd30681c81c0,
-        type: 3}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9cfa9c37b98744a449e7c0127f470a30, type: 3}
---- !u!4 &1191726038 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
-    type: 3}
-  m_PrefabInstance: {fileID: 1191726037}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1198879341
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 33146209}
-    m_Modifications:
-    - target: {fileID: 1528725312502566776, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1.18
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.1799996
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1.1799995
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -29.20532
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -27.125687
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -92.61322
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.99953806
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.016289156
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.022152629
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.012949174
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 1.833
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 2.564
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 1.525
-      objectReference: {fileID: 0}
-    - target: {fileID: 7349414926691905503, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_Name
-      value: cloud_medium (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 7859370079127710536, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 205163206283e7a40838be91cdc4eee7, type: 2}
-    m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 8737101222051999724, guid: 5afb8b4ced538e949ba0d67073aa9e5c, type: 3}
-    - {fileID: 506987933308232340, guid: 5afb8b4ced538e949ba0d67073aa9e5c, type: 3}
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 5afb8b4ced538e949ba0d67073aa9e5c, type: 3}
---- !u!4 &1198879342 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-    type: 3}
-  m_PrefabInstance: {fileID: 1198879341}
-  m_PrefabAsset: {fileID: 0}
---- !u!21 &1239816348
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 0.99999994, a: 1}
-    - _WidthHeightRadius: {r: 1275.0493, g: 849.3999, b: 80, a: 0}
-  m_BuildTextureStacks: []
---- !u!1001 &1242796678
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 33146209}
-    m_Modifications:
-    - target: {fileID: 1393713133580456719, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_Name
-      value: Star (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1523659555437022603, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: -5801228030656462994, guid: 879532fb680028b48a18fd30681c81c0,
-        type: 3}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 37.129868
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -19.519333
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -234.33228
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.9455583
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.32545283
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -37.986
-      objectReference: {fileID: 0}
-    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d, type: 3}
---- !u!4 &1242796679 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
-    type: 3}
-  m_PrefabInstance: {fileID: 1242796678}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1272773744
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1272773745}
-  m_Layer: 0
-  m_Name: 1P
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1272773745
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1272773744}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.45714784, y: 38.12265, z: 53.653408}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5028936980023486864}
-  - {fileID: 5459661996259786999}
-  - {fileID: 4012408829042898441}
-  - {fileID: 7858180841353959115}
-  - {fileID: 2468972318733881315}
-  - {fileID: 8110684590907827956}
-  - {fileID: 3276256650029411315}
-  - {fileID: 2921430010422554358}
-  - {fileID: 634983479888591}
-  - {fileID: 5383682927402170594}
-  - {fileID: 8195928822571489098}
-  - {fileID: 285159666094078403}
-  - {fileID: 3610911797514433177}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1288740885
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1217284196904556031, guid: bd6c411af2463804291825c789c17218,
-        type: 3}
-      propertyPath: gameTime
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 1217284196904556031, guid: bd6c411af2463804291825c789c17218,
-        type: 3}
-      propertyPath: remainingTime
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1217284196904556031, guid: bd6c411af2463804291825c789c17218,
-        type: 3}
-      propertyPath: mainMapSceneName
-      value: Test_LTHLobbyScene
-      objectReference: {fileID: 0}
-    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 7.5236197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 5.509158
-      objectReference: {fileID: 0}
-    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 5.135033
-      objectReference: {fileID: 0}
-    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7053311724175509580, guid: bd6c411af2463804291825c789c17218,
-        type: 3}
-      propertyPath: m_Name
-      value: JengaGameManager
-      objectReference: {fileID: 0}
-    - target: {fileID: 7053311724175509580, guid: bd6c411af2463804291825c789c17218,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bd6c411af2463804291825c789c17218, type: 3}
---- !u!21 &1350916879
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0.024052067, g: 0.022535274, b: 0.9789449, a: 0.9755116}
-    - _WidthHeightRadius: {r: 1192.5742, g: 319.42212, b: 80, a: 0}
-  m_BuildTextureStacks: []
---- !u!1001 &1361621134
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 33146209}
-    m_Modifications:
-    - target: {fileID: 22155592255493168, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 33187889994166660, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 36720549068965476, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 36720549068965476, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 40739383538924940, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 40739383538924940, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 100472204946717246, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 214471159406620688, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 214471159406620688, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 234383908846435269, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 234383908846435269, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 290449607962369803, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 411230144369684253, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 418895182582908881, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 432594463758014904, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 538812339818583084, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 650298653024955773, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 650298653024955773, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 746736232423939768, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 783714491651055537, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 783714491651055537, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
-    - target: {fileID: 798409471190121737, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 922584556582370979, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 1195553248919788488, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
-    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -35.603638
-      objectReference: {fileID: 0}
-    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -36.852615
-      objectReference: {fileID: 0}
-    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -67.65619
-      objectReference: {fileID: 0}
-    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.9991457
-      objectReference: {fileID: 0}
     - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
       propertyPath: m_LocalRotation.x
@@ -7137,7 +2215,7 @@ PrefabInstance:
     - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.041328084
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
@@ -7152,7 +2230,7 @@ PrefabInstance:
     - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 4.737
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
@@ -7779,13 +2857,13 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 870433e8f73f4f74ab76a6188d5fadef, type: 3}
---- !u!4 &1361621135 stripped
+--- !u!4 &371573363 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
     type: 3}
-  m_PrefabInstance: {fileID: 1361621134}
+  m_PrefabInstance: {fileID: 371573362}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1368305594
+--- !u!1 &392257174
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -7793,42 +2871,348 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1368305595}
+  - component: {fileID: 392257178}
+  - component: {fileID: 392257177}
+  - component: {fileID: 392257176}
+  - component: {fileID: 392257175}
   m_Layer: 0
-  m_Name: 4P
+  m_Name: CollapseCam
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1368305595
+  m_IsActive: 0
+--- !u!114 &392257175
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 392257174}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 94a1a611ffc92aa47a85fe13856c093e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 392257177}
+  targetRT: {fileID: 483322393}
+  rtSize: {x: 512, y: 512}
+  offset: {x: 0, y: 2.2, z: -3}
+  fov: 40
+  lookUpOffset: 0.3
+--- !u!114 &392257176
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 392257174}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+--- !u!20 &392257177
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 392257174}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 40
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 0
+  m_AllowMSAA: 0
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &392257178
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1368305594}
+  m_GameObject: {fileID: 392257174}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -28.457148, y: 38.12265, z: 28.653414}
+  m_LocalPosition: {x: 158.84209, y: 268.27615, z: -28.395874}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1558434041}
-  - {fileID: 1907386682}
-  - {fileID: 1626050112}
-  - {fileID: 1191726038}
-  - {fileID: 347552063}
-  - {fileID: 717713851}
-  - {fileID: 1728579987}
-  - {fileID: 197854450}
-  - {fileID: 487881568}
-  - {fileID: 1979129520}
-  - {fileID: 1534520122}
-  - {fileID: 891583930}
+  m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1375761812
+--- !u!1001 &393201830
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 201037551}
+    m_Modifications:
+    - target: {fileID: 1528725312502566776, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.18
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.1799996
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.1799996
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 39.8947
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -28.125717
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -62.39669
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9995996
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.015740076
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.019175291
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.013611314
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 1.833
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -2.174
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 1.525
+      objectReference: {fileID: 0}
+    - target: {fileID: 7349414926691905503, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_Name
+      value: cloud_medium (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7859370079127710536, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 205163206283e7a40838be91cdc4eee7, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 8737101222051999724, guid: 5afb8b4ced538e949ba0d67073aa9e5c, type: 3}
+    - {fileID: 506987933308232340, guid: 5afb8b4ced538e949ba0d67073aa9e5c, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5afb8b4ced538e949ba0d67073aa9e5c, type: 3}
+--- !u!4 &393201831 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+    type: 3}
+  m_PrefabInstance: {fileID: 393201830}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &405587643
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 669275690}
+    m_Modifications:
+    - target: {fileID: 1528725312502566776, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.18
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.1799996
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.1799996
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 39.8947
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -28.125717
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -62.39669
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9995996
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.015740076
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.019175291
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.013611314
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 1.833
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -2.174
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 1.525
+      objectReference: {fileID: 0}
+    - target: {fileID: 7349414926691905503, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_Name
+      value: cloud_medium (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7859370079127710536, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 205163206283e7a40838be91cdc4eee7, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 8737101222051999724, guid: 5afb8b4ced538e949ba0d67073aa9e5c, type: 3}
+    - {fileID: 506987933308232340, guid: 5afb8b4ced538e949ba0d67073aa9e5c, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5afb8b4ced538e949ba0d67073aa9e5c, type: 3}
+--- !u!4 &405587644 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+    type: 3}
+  m_PrefabInstance: {fileID: 405587643}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &407208379
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -7836,102 +3220,85 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1375761813}
-  - component: {fileID: 1375761816}
-  - component: {fileID: 1375761815}
-  - component: {fileID: 1375761814}
+  - component: {fileID: 407208380}
+  - component: {fileID: 407208383}
+  - component: {fileID: 407208382}
+  - component: {fileID: 407208381}
   m_Layer: 5
-  m_Name: Option
+  m_Name: BottomPanel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &1375761813
+--- !u!224 &407208380
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1375761812}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_GameObject: {fileID: 407208379}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 231174370}
   m_Father: {fileID: 419628864}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 982, y: -290}
-  m_SizeDelta: {x: 157.32251, y: 142.82007}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 80.1582}
+  m_SizeDelta: {x: 1082, y: 160.317}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1375761814
+--- !u!114 &407208381
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1375761812}
+  m_GameObject: {fileID: 407208379}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 1375761815}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!114 &1375761815
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &407208382
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1375761812}
+  m_GameObject: {fileID: 407208379}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 7d7558e5ca1ea9f43824b4279dcc4609, type: 3}
-  m_Type: 0
+  m_Sprite: {fileID: 21300000, guid: 5f8f1c8354b9741f0921ae0eef8aa970, type: 3}
+  m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -7940,21 +3307,528 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!222 &1375761816
+--- !u!222 &407208383
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1375761812}
+  m_GameObject: {fileID: 407208379}
   m_CullTransparentMesh: 1
---- !u!1001 &1438362380
+--- !u!1 &410087039
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 410087041}
+  - component: {fileID: 410087040}
+  - component: {fileID: 410087042}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &410087040
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 410087039}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 2
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 5000
+  m_UseColorTemperature: 1
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &410087041
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 410087039}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!114 &410087042
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 410087039}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 1
+--- !u!1001 &415344788
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 344144929}
+    m_TransformParent: {fileID: 201037551}
+    m_Modifications:
+    - target: {fileID: 3249078544740656951, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_Name
+      value: obj_BackGround (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 149.99998
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 150.00002
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 189.45715
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -232.12268
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -807.15344
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.261213
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.17311928
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.84264374
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.43789166
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -55.936
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 148.985
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -6.457
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 53d824376eb53224785cb081a314aae8, type: 3}
+--- !u!4 &415344789 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+    type: 3}
+  m_PrefabInstance: {fileID: 415344788}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &419628863
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547428902181905421, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885039544089571689, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_Name
+      value: Canvas
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885039544089571689, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8510048701061075239, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      propertyPath: m_AdditionalShaderChannelsFlag
+      value: 25
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1648873810}
+    - targetCorrespondingSourceObject: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 938219810}
+    - targetCorrespondingSourceObject: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 132007708}
+    - targetCorrespondingSourceObject: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1934672920}
+    - targetCorrespondingSourceObject: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1375761813}
+    - targetCorrespondingSourceObject: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 407208380}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b4f2cd633f84448609793082bcf66d70, type: 3}
+--- !u!224 &419628864 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
+    type: 3}
+  m_PrefabInstance: {fileID: 419628863}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &428407027
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 428407028}
+  m_Layer: 0
+  m_Name: CameraAnchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &428407028
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 428407027}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.046350844, y: 0.94876266, z: -0.16409896, w: 0.266031}
+  m_LocalPosition: {x: -6.55, y: 9.370001, z: 11.38}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 859200890}
+  m_LocalEulerAnglesHint: {x: 19.636, y: 148.68, z: 0.039}
+--- !u!1001 &430501340
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 669275690}
+    m_Modifications:
+    - target: {fileID: 614895130769055622, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
+    - target: {fileID: 4603879714568064926, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: d7cd310ef634a034abab2d9806894dc9, type: 2}
+    - target: {fileID: 5066022526432343303, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.26985377
+      objectReference: {fileID: 0}
+    - target: {fileID: 5066022526432343303, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5066022526432343303, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.48957014
+      objectReference: {fileID: 0}
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 30.021023
+      objectReference: {fileID: 0}
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -35.87265
+      objectReference: {fileID: 0}
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -41.337597
+      objectReference: {fileID: 0}
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.020058993
+      objectReference: {fileID: 0}
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.9997988
+      objectReference: {fileID: 0}
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -177.701
+      objectReference: {fileID: 0}
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6508736201795955369, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_Name
+      value: cloud_small (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 3807266887916899018, guid: 14d72a544b3ee7e49a3e59a75ff170ec, type: 3}
+    - {fileID: 1027792874845127237, guid: 14d72a544b3ee7e49a3e59a75ff170ec, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 14d72a544b3ee7e49a3e59a75ff170ec, type: 3}
+--- !u!4 &430501341 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+    type: 3}
+  m_PrefabInstance: {fileID: 430501340}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &476647885
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1512531044}
     m_Modifications:
     - target: {fileID: 329657563048967457, guid: 3c00ec95b49c1d546a217a587c86b37e,
         type: 3}
@@ -7965,47 +3839,47 @@ PrefabInstance:
     - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.44314992
+      value: 0.44314995
       objectReference: {fileID: 0}
     - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 0.44315007
+      value: 0.44315004
       objectReference: {fileID: 0}
     - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -141.18695
+      value: 28.955816
       objectReference: {fileID: 0}
     - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -36.929886
+      value: -37.92992
       objectReference: {fileID: 0}
     - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -124.025635
+      value: -36.122665
       objectReference: {fileID: 0}
     - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.947194
+      value: 0.93779
       objectReference: {fileID: 0}
     - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.23615153
+      value: -0.2384999
       objectReference: {fileID: 0}
     - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.2079633
+      value: -0.24693131
       objectReference: {fileID: 0}
     - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.06170368
+      value: 0.05189126
       objectReference: {fileID: 0}
     - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
         type: 3}
@@ -8015,7 +3889,7 @@ PrefabInstance:
     - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: -27.815
+      value: -32.553
       objectReference: {fileID: 0}
     - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
         type: 3}
@@ -8025,26 +3899,26 @@ PrefabInstance:
     - target: {fileID: 6411628229678914976, guid: 3c00ec95b49c1d546a217a587c86b37e,
         type: 3}
       propertyPath: m_Name
-      value: Star (7)
+      value: Star (5)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3c00ec95b49c1d546a217a587c86b37e, type: 3}
---- !u!4 &1438362381 stripped
+--- !u!4 &476647886 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
     type: 3}
-  m_PrefabInstance: {fileID: 1438362380}
+  m_PrefabInstance: {fileID: 476647885}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1496346194
+--- !u!1001 &479623930
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 344144929}
+    m_TransformParent: {fileID: 669275690}
     m_Modifications:
     - target: {fileID: 22155592255493168, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
@@ -8169,22 +4043,22 @@ PrefabInstance:
     - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -138.85364
+      value: 31.457148
       objectReference: {fileID: 0}
     - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -36.852615
+      value: -37.85265
       objectReference: {fileID: 0}
     - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -127.3
+      value: -38.053413
       objectReference: {fileID: 0}
     - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9991457
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
@@ -8194,7 +4068,7 @@ PrefabInstance:
     - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.041328084
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
@@ -8209,7 +4083,7 @@ PrefabInstance:
     - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 4.737
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
@@ -8809,7 +4683,7 @@ PrefabInstance:
     - target: {fileID: 9064418881484696250, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
       propertyPath: m_Name
-      value: SM_Jenga_Tower_1 (1)
+      value: SM_Jenga_Tower_1
       objectReference: {fileID: 0}
     - target: {fileID: 9064418881484696250, guid: 870433e8f73f4f74ab76a6188d5fadef,
         type: 3}
@@ -8836,19 +4710,57 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 870433e8f73f4f74ab76a6188d5fadef, type: 3}
---- !u!4 &1496346195 stripped
+--- !u!4 &479623931 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
     type: 3}
-  m_PrefabInstance: {fileID: 1496346194}
+  m_PrefabInstance: {fileID: 479623930}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1534520121
+--- !u!84 &483322393
+RenderTexture:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_ImageContentsHash:
+    serializedVersion: 2
+    Hash: 00000000000000000000000000000000
+  m_ForcedFallbackFormat: 4
+  m_DownscaleFallback: 0
+  m_IsAlphaChannelOptional: 0
+  serializedVersion: 5
+  m_Width: 1024
+  m_Height: 1024
+  m_AntiAliasing: 1
+  m_MipCount: -1
+  m_DepthStencilFormat: 90
+  m_ColorFormat: 4
+  m_MipMap: 0
+  m_GenerateMips: 0
+  m_SRGB: 1
+  m_UseDynamicScale: 0
+  m_BindMS: 0
+  m_EnableCompatibleFormat: 1
+  m_EnableRandomWrite: 0
+  m_TextureSettings:
+    serializedVersion: 2
+    m_FilterMode: 1
+    m_Aniso: 0
+    m_MipBias: 0
+    m_WrapU: 1
+    m_WrapV: 1
+    m_WrapW: 1
+  m_Dimension: 2
+  m_VolumeDepth: 1
+  m_ShadowSamplingMode: 2
+--- !u!1001 &486016269
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1368305595}
+    m_TransformParent: {fileID: 1512531044}
     m_Modifications:
     - target: {fileID: 205199232430197985, guid: e877e31156c607e46a5319bffdd8e6a6,
         type: 3}
@@ -8883,37 +4795,37 @@ PrefabInstance:
     - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -227.21011
+      value: 34.973694
       objectReference: {fileID: 0}
     - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -37.128113
+      value: -38.12815
       objectReference: {fileID: 0}
     - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -191.88205
+      value: -36.690258
       objectReference: {fileID: 0}
     - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.86264426
+      value: 0.8411365
       objectReference: {fileID: 0}
     - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.032707438
+      value: -0.030746298
       objectReference: {fileID: 0}
     - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.5025806
+      value: -0.53780264
       objectReference: {fileID: 0}
     - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.046776246
+      value: -0.048088007
       objectReference: {fileID: 0}
     - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
         type: 3}
@@ -8923,7 +4835,7 @@ PrefabInstance:
     - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: -60.308
+      value: -65.045
       objectReference: {fileID: 0}
     - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
         type: 3}
@@ -8948,7 +4860,7 @@ PrefabInstance:
     - target: {fileID: 4091603727724860672, guid: e877e31156c607e46a5319bffdd8e6a6,
         type: 3}
       propertyPath: m_Name
-      value: CH004_Jeomboon_ST000 (4)
+      value: CH004_Jeomboon_ST000
       objectReference: {fileID: 0}
     - target: {fileID: 4091603727724860672, guid: e877e31156c607e46a5319bffdd8e6a6,
         type: 3}
@@ -9030,11 +4942,4254 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e877e31156c607e46a5319bffdd8e6a6, type: 3}
---- !u!4 &1534520122 stripped
+--- !u!4 &486016270 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
     type: 3}
-  m_PrefabInstance: {fileID: 1534520121}
+  m_PrefabInstance: {fileID: 486016269}
+  m_PrefabAsset: {fileID: 0}
+--- !u!21 &510692240
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0.024052067, g: 0.022535274, b: 0.9789449, a: 0.9755116}
+    - _WidthHeightRadius: {r: 1192.5742, g: 319.42212, b: 80, a: 0}
+  m_BuildTextureStacks: []
+--- !u!1 &545133229
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 545133231}
+  - component: {fileID: 545133230}
+  m_Layer: 0
+  m_Name: JengaPhotonViewCoordinator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &545133230
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 545133229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 48c2c32953764648bd684ac38a9d4b47, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneViews: []
+  roots: []
+--- !u!4 &545133231
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 545133229}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -4.654665, y: -5.1745243, z: 13.160173}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &580941682
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 580941683}
+  - component: {fileID: 580941685}
+  - component: {fileID: 580941684}
+  m_Layer: 5
+  m_Name: SelectionRect
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &580941683
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 580941682}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 254962753}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &580941684
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 580941682}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: d6e723ac92a5e1d4eb2e756bb613e140, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &580941685
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 580941682}
+  m_CullTransparentMesh: 1
+--- !u!1 &586440522
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 586440524}
+  - component: {fileID: 586440523}
+  m_Layer: 0
+  m_Name: JengaLocalCamreaBinder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &586440523
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 586440522}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5bd94555db73ec84a845da430237c75c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  vcamPrefab: {fileID: 3382513035572775980, guid: c9cd8d7c7520074449b8b9e41941637a,
+    type: 3}
+  commonLayers:
+    serializedVersion: 2
+    m_Bits: 33
+--- !u!4 &586440524
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 586440522}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 26.497707, y: -0.39967346, z: 7.6236916}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &589300098
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 669275690}
+    m_Modifications:
+    - target: {fileID: 5651446509498788021, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_Name
+      value: Star (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 72.707146
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -68.01936
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -183.90341
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9313001
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.36425287
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -42.723
+      objectReference: {fileID: 0}
+    - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7120867635128088013, guid: 9cfa9c37b98744a449e7c0127f470a30,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: -5801228030656462994, guid: 879532fb680028b48a18fd30681c81c0,
+        type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9cfa9c37b98744a449e7c0127f470a30, type: 3}
+--- !u!4 &589300099 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
+    type: 3}
+  m_PrefabInstance: {fileID: 589300098}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &608810663
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 669275690}
+    m_Modifications:
+    - target: {fileID: 100539952889884493, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 205163206283e7a40838be91cdc4eee7, type: 2}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.43432003
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.43431997
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 31.18511
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -36.62358
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -33.41142
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9524369
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.09550917
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.28929576
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.007060775
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -10.244
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -34.151
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 4.004
+      objectReference: {fileID: 0}
+    - target: {fileID: 5405934403816150963, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5405934403816150963, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
+    - target: {fileID: 7581750188737525860, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_Name
+      value: cloud_medium (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 7186054671757280169, guid: 03e21b53685994d43a092c2d1b9c6a84, type: 3}
+    - {fileID: 7084152554214074933, guid: 03e21b53685994d43a092c2d1b9c6a84, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 03e21b53685994d43a092c2d1b9c6a84, type: 3}
+--- !u!4 &608810664 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+    type: 3}
+  m_PrefabInstance: {fileID: 608810663}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &629855328
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1512531044}
+    m_Modifications:
+    - target: {fileID: 1393713133580456719, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_Name
+      value: Star (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1523659555437022603, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: -5801228030656462994, guid: 879532fb680028b48a18fd30681c81c0,
+        type: 3}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 117.707146
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -20.519367
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -198.15341
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9313001
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.36425287
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -42.723
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d, type: 3}
+--- !u!4 &629855329 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+    type: 3}
+  m_PrefabInstance: {fileID: 629855328}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &669275689
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 669275690}
+  m_Layer: 0
+  m_Name: 3P
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &669275690
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 669275689}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -31.727148, y: 37.963623, z: 38.393406}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 479623931}
+  - {fileID: 1067012251}
+  - {fileID: 1705364806}
+  - {fileID: 2100874808}
+  - {fileID: 589300099}
+  - {fileID: 240813965}
+  - {fileID: 1733294413}
+  - {fileID: 430501341}
+  - {fileID: 915630214}
+  - {fileID: 608810664}
+  - {fileID: 405587644}
+  - {fileID: 1747515293}
+  - {fileID: 1545194026}
+  m_Father: {fileID: 859200890}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &701912561
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1512531044}
+    m_Modifications:
+    - target: {fileID: 1528725312502566776, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.18
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.1799996
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.1799996
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 39.8947
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -28.125717
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -62.39669
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9995996
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.015740076
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.019175291
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.013611314
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 1.833
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -2.174
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 1.525
+      objectReference: {fileID: 0}
+    - target: {fileID: 7349414926691905503, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_Name
+      value: cloud_medium (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7859370079127710536, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 205163206283e7a40838be91cdc4eee7, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 8737101222051999724, guid: 5afb8b4ced538e949ba0d67073aa9e5c, type: 3}
+    - {fileID: 506987933308232340, guid: 5afb8b4ced538e949ba0d67073aa9e5c, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5afb8b4ced538e949ba0d67073aa9e5c, type: 3}
+--- !u!4 &701912562 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+    type: 3}
+  m_PrefabInstance: {fileID: 701912561}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &704486632
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1512531044}
+    m_Modifications:
+    - target: {fileID: 22155592255493168, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 33187889994166660, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 36720549068965476, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 36720549068965476, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 40739383538924940, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 40739383538924940, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 100472204946717246, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 214471159406620688, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 214471159406620688, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 234383908846435269, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 234383908846435269, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 290449607962369803, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 411230144369684253, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 418895182582908881, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 432594463758014904, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 538812339818583084, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 650298653024955773, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 650298653024955773, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 746736232423939768, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 783714491651055537, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 783714491651055537, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 798409471190121737, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 922584556582370979, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 1195553248919788488, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 31.457148
+      objectReference: {fileID: 0}
+    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -37.85265
+      objectReference: {fileID: 0}
+    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -38.053413
+      objectReference: {fileID: 0}
+    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1340917988430205607, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1340917988430205607, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 1495097847972775850, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1495097847972775850, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 1596267127136250158, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1596267127136250158, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 1665415229873288315, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 1736378830458349675, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 1845784568966000089, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1845784568966000089, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 2038612119992206113, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 2076882152173295359, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 2153432934900547576, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 2155132447699492003, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 2308337712043047829, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 2375386941894113963, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 2404667205930070138, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 2406401350878136260, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2406401350878136260, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 2661396680078406401, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 2722753316705796921, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2722753316705796921, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 2771923637222776831, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2771923637222776831, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 2787308115362846088, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 2839867045486128883, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2839867045486128883, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 2885084885758892758, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2885084885758892758, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 2887690281359775391, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2887690281359775391, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 2992135530745749749, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 3001849979441450719, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 3005727962097887924, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3005727962097887924, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 3041196279614361117, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3041196279614361117, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 3261009662981286812, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 3416674001866434362, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416674001866434362, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 3505705461291080819, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3505705461291080819, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 3531231261470652379, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.0497
+      objectReference: {fileID: 0}
+    - target: {fileID: 3800455879800047648, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 3994959866047517518, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3994959866047517518, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 4140304655994197350, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4140304655994197350, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 4188343569351860611, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 4196060385186400686, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 4197595123226478936, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4197595123226478936, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 4339274808398475724, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4339274808398475724, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 4344405680525151917, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 4349141498655887898, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 4398894214655572765, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4398894214655572765, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 4464510989897335917, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 4832482362144014220, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4832482362144014220, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 4848909546885351958, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4848909546885351958, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 4896016000791029342, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4896016000791029342, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 5096764325150322401, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5096764325150322401, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 5116273792172264949, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5116273792172264949, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 5252997337185806556, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 5260347511967309562, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 5349660182146679502, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 5603477323529394169, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5603477323529394169, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 5808853389497651303, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 5817699679196710845, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817699679196710845, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 6139898067430685923, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6139898067430685923, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 6210173168455794465, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6210173168455794465, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 6291494815040878487, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 6550029043274057131, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6550029043274057131, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 6601849725924175426, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6601849725924175426, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 6873858858885959258, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6873858858885959258, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 6887620469895559334, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 6917070216655512044, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6917070216655512044, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 6921410993619055940, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6921410993619055940, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 7014733665442605631, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7014733665442605631, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 7069958683730946128, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 7179605924460934488, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7179605924460934488, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 7293422265078263754, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7293422265078263754, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 7298045014559106539, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 7476504372083623875, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 7492815276572038720, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 7500020107541243142, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 7652479989106242777, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 7707041019526897873, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7707041019526897873, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 7910866339413639222, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7910866339413639222, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 8005340992367534437, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 8091382583360473318, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8091382583360473318, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 8290480986608609771, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8290480986608609771, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 8414897384260690424, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8414897384260690424, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    - target: {fileID: 8568582946995555276, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 9020946318807993640, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 9064418881484696250, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Name
+      value: SM_Jenga_Tower_1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9064418881484696250, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9087388445363831751, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 3c6137de948f08a48838bae63350489c, type: 2}
+    - target: {fileID: 9163585210480661473, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9163585210480661473, guid: 870433e8f73f4f74ab76a6188d5fadef,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 79d2ee8c68840124f98054916fe56d1d, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 870433e8f73f4f74ab76a6188d5fadef, type: 3}
+--- !u!4 &704486633 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1268919860608705550, guid: 870433e8f73f4f74ab76a6188d5fadef,
+    type: 3}
+  m_PrefabInstance: {fileID: 704486632}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &748278359
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 562723092912506160, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -164.19
+      objectReference: {fileID: 0}
+    - target: {fileID: 562723092912506160, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 562723092912506160, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -101.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 562723092912506160, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 562723092912506160, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 562723092912506160, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 562723092912506160, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 562723092912506160, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 609052281688899841, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.26
+      objectReference: {fileID: 0}
+    - target: {fileID: 1057033014272698073, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1372719524002692937, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1463674121782452736, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 1463674121782452736, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.08
+      objectReference: {fileID: 0}
+    - target: {fileID: 2451782784813004358, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 2703642404708267145, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -63.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 2703642404708267145, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 2703642404708267145, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -42.21
+      objectReference: {fileID: 0}
+    - target: {fileID: 2703642404708267145, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2703642404708267145, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2703642404708267145, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2703642404708267145, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2703642404708267145, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2859464421426194495, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 30.51
+      objectReference: {fileID: 0}
+    - target: {fileID: 2859464421426194495, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.14
+      objectReference: {fileID: 0}
+    - target: {fileID: 2859464421426194495, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 12.88
+      objectReference: {fileID: 0}
+    - target: {fileID: 2859464421426194495, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2859464421426194495, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2859464421426194495, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2859464421426194495, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2859464421426194495, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3226987432599523960, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3879852811759145387, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4550220700672617421, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4625638008536974983, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -6.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 4660228575036585631, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701654860940241262, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.83
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701654860940241262, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.12
+      objectReference: {fileID: 0}
+    - target: {fileID: 6141946945002473970, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.73
+      objectReference: {fileID: 0}
+    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.23845437
+      objectReference: {fileID: 0}
+    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7209915223178915543, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7500476990348501097, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7830282080685953408, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 7830282080685953408, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997442498939513690, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -255.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997442498939513690, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997442498939513690, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -167.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997442498939513690, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997442498939513690, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997442498939513690, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997442498939513690, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997442498939513690, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8011586431347609675, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: arenaTowerAnchors.Array.data[1]
+      value: 
+      objectReference: {fileID: 363694453}
+    - target: {fileID: 8011586431347609675, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: arenaTowerAnchors.Array.data[2]
+      value: 
+      objectReference: {fileID: 921047187}
+    - target: {fileID: 8011586431347609675, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: arenaTowerAnchors.Array.data[3]
+      value: 
+      objectReference: {fileID: 315647960}
+    - target: {fileID: 8011586431347609675, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: arenaCameraAnchors.Array.data[1]
+      value: 
+      objectReference: {fileID: 757328113}
+    - target: {fileID: 8011586431347609675, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: arenaCameraAnchors.Array.data[2]
+      value: 
+      objectReference: {fileID: 428407028}
+    - target: {fileID: 8011586431347609675, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: arenaCameraAnchors.Array.data[3]
+      value: 
+      objectReference: {fileID: 908722768}
+    - target: {fileID: 8068020423338431611, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8280847053682877144, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8435625876723763533, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8466552122991562632, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9043512953739879483, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_Name
+      value: JengaTowerManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 9152528478550071037, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.58
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 3226987432599523960, guid: fe50d52b558578d43beb59995e9a9ca4, type: 3}
+    - {fileID: 8068020423338431611, guid: fe50d52b558578d43beb59995e9a9ca4, type: 3}
+    - {fileID: 4550220700672617421, guid: fe50d52b558578d43beb59995e9a9ca4, type: 3}
+    - {fileID: 7500476990348501097, guid: fe50d52b558578d43beb59995e9a9ca4, type: 3}
+    - {fileID: 4660228575036585631, guid: fe50d52b558578d43beb59995e9a9ca4, type: 3}
+    - {fileID: 1057033014272698073, guid: fe50d52b558578d43beb59995e9a9ca4, type: 3}
+    - {fileID: 1372719524002692937, guid: fe50d52b558578d43beb59995e9a9ca4, type: 3}
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 5972180381225883934, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1110847946}
+    - targetCorrespondingSourceObject: {fileID: 5972180381225883934, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 859200890}
+    - targetCorrespondingSourceObject: {fileID: 5972180381225883934, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1460646842}
+    - targetCorrespondingSourceObject: {fileID: 2859464421426194495, guid: fe50d52b558578d43beb59995e9a9ca4,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1272773745}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fe50d52b558578d43beb59995e9a9ca4, type: 3}
+--- !u!4 &748278360 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5972180381225883934, guid: fe50d52b558578d43beb59995e9a9ca4,
+    type: 3}
+  m_PrefabInstance: {fileID: 748278359}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &748278361 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2859464421426194495, guid: fe50d52b558578d43beb59995e9a9ca4,
+    type: 3}
+  m_PrefabInstance: {fileID: 748278359}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &757328112
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 757328113}
+  m_Layer: 0
+  m_Name: CameraAnchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &757328113
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 757328112}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.046350844, y: 0.94876266, z: -0.16409896, w: 0.266031}
+  m_LocalPosition: {x: -6.55, y: 9.370001, z: 11.38}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1110847946}
+  m_LocalEulerAnglesHint: {x: 19.636, y: 148.68, z: 0.039}
+--- !u!1 &760830003
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 760830004}
+  - component: {fileID: 760830006}
+  - component: {fileID: 760830005}
+  m_Layer: 5
+  m_Name: OverlayRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &760830004
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 760830003}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1637472400}
+  - {fileID: 875495119}
+  m_Father: {fileID: 201836501}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!225 &760830005
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 760830003}
+  m_Enabled: 1
+  m_Alpha: 0
+  m_Interactable: 0
+  m_BlocksRaycasts: 0
+  m_IgnoreParentGroups: 0
+--- !u!114 &760830006
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 760830003}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f6f614f7bd59cd640bf929365a2bfa66, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  group: {fileID: 760830005}
+  preview: {fileID: 254962754}
+  okButton: {fileID: 1535448053}
+  backdrop: {fileID: 1637472401}
+  towerCam: {fileID: 2139196078}
+  useOrthographic: 1
+  padding: 1.3
+  orthoCamDist: 3
+  slightTiltDeg: 0
+  layerWidth: 3
+  layerHeightMultiplier: 2
+  zoomFactor: 0.7
+  worldFrontBasis: {fileID: 0}
+  invertWorldFront: 0
+  arenaMask:
+    serializedVersion: 2
+    m_Bits: 30720
+--- !u!1001 &766586352
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1512531044}
+    m_Modifications:
+    - target: {fileID: 3249078544740656951, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_Name
+      value: obj_BackGround (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 149.99998
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 150.00002
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 189.45715
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -232.12268
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -807.15344
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.261213
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.17311928
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.84264374
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.43789166
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -55.936
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 148.985
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -6.457
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 53d824376eb53224785cb081a314aae8, type: 3}
+--- !u!4 &766586353 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+    type: 3}
+  m_PrefabInstance: {fileID: 766586352}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &778023254
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 778023255}
+  m_Layer: 0
+  m_Name: ---------Bootstrap------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &778023255
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 778023254}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 24.953793, y: -12.302406, z: -145.06204}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &778223936
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 778223937}
+  m_Layer: 0
+  m_Name: -------------------------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &778223937
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 778223936}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 306.63657, y: 1225.811, z: -3.3471224}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 956063945}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!21 &794713411
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 0.99999994, a: 1}
+    - _WidthHeightRadius: {r: 1275.0493, g: 849.3999, b: 80, a: 0}
+  m_BuildTextureStacks: []
+--- !u!1 &832575517
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 832575519}
+  - component: {fileID: 832575518}
+  m_Layer: 0
+  m_Name: Global Volume
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &832575518
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 832575517}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 172515602e62fb746b5d573b38a5fe58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IsGlobal: 1
+  priority: 0
+  blendDistance: 0
+  weight: 1
+  sharedProfile: {fileID: 11400000, guid: a6560a915ef98420e9faacc1c7438823, type: 2}
+--- !u!4 &832575519
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 832575517}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &835420898
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 835420899}
+  - component: {fileID: 835420902}
+  - component: {fileID: 835420901}
+  - component: {fileID: 835420900}
+  m_Layer: 5
+  m_Name: Timer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &835420899
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 835420898}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3.5999994, y: 3.5999994, z: 3.5999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 29469106}
+  - {fileID: 1867122146}
+  m_Father: {fileID: 1934672920}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 149.651, y: 51.939}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &835420900
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 835420898}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: adb30198aa32dd140b5750692dd48104, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  radius: 20
+  image: {fileID: 835420901}
+--- !u!114 &835420901
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 835420898}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 1601309345}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 24160931ebfa44f2f8c9452c96dacd00, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &835420902
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 835420898}
+  m_CullTransparentMesh: 1
+--- !u!1 &859200889
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 859200890}
+  m_Layer: 13
+  m_Name: Arena_2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &859200890
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 859200889}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -165, y: 1.14, z: -104}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 921047187}
+  - {fileID: 428407028}
+  - {fileID: 669275690}
+  m_Father: {fileID: 748278360}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &872848296
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 116.216644
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 130.18143
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 11.598944
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1108038756419047845, guid: f00d8d7cec95f9f44a648ba384285527,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1620587405723649436, guid: f00d8d7cec95f9f44a648ba384285527,
+        type: 3}
+      propertyPath: m_Name
+      value: JengaTimingManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 2658409117490003364, guid: f00d8d7cec95f9f44a648ba384285527,
+        type: 3}
+      propertyPath: timingUI
+      value: 
+      objectReference: {fileID: 1804809742}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f00d8d7cec95f9f44a648ba384285527, type: 3}
+--- !u!1 &875495118
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 875495119}
+  - component: {fileID: 875495121}
+  - component: {fileID: 875495120}
+  m_Layer: 5
+  m_Name: TowerFocusOverlayPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &875495119
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 875495118}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 254962753}
+  - {fileID: 1535448052}
+  m_Father: {fileID: 760830004}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0.00024414062, y: -283.57782}
+  m_SizeDelta: {x: 1080, y: 795.86414}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &875495120
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 875495118}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 87ff1ad01a5c8a24286a1dc24db49657, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &875495121
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 875495118}
+  m_CullTransparentMesh: 1
+--- !u!1 &883198816
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 883198817}
+  m_Layer: 0
+  m_Name: ------------UI----------------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &883198817
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 883198816}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 116.216644, y: 130.18143, z: 11.598944}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &893449271
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 893449274}
+  - component: {fileID: 893449273}
+  - component: {fileID: 893449272}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &893449272
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893449271}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 1
+  m_CursorLockBehavior: 0
+  m_ScrollDeltaPerTick: 6
+--- !u!114 &893449273
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893449271}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &893449274
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893449271}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &908722767
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 908722768}
+  m_Layer: 0
+  m_Name: CameraAnchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &908722768
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 908722767}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.046350844, y: 0.94876266, z: -0.16409896, w: 0.266031}
+  m_LocalPosition: {x: -6.55, y: 9.370001, z: 11.38}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1460646842}
+  m_LocalEulerAnglesHint: {x: 19.636, y: 148.68, z: 0.039}
+--- !u!1001 &915630213
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 669275690}
+    m_Modifications:
+    - target: {fileID: 2384014560097971772, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: d7cd310ef634a034abab2d9806894dc9, type: 2}
+    - target: {fileID: 2653175844725749233, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2653175844725749233, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
+    - target: {fileID: 5541878569053640991, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_Name
+      value: cloud_small (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 37.93715
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -34.16265
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -40.213413
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.70469546
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.023644142
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7087042
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.02415966
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -3.874
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -269.676
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0.031
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 936855253423794581, guid: 0819da63da0b50042a487510d69c6550, type: 3}
+    - {fileID: 3124346702935965148, guid: 0819da63da0b50042a487510d69c6550, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0819da63da0b50042a487510d69c6550, type: 3}
+--- !u!4 &915630214 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+    type: 3}
+  m_PrefabInstance: {fileID: 915630213}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &916606201
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 201037551}
+    m_Modifications:
+    - target: {fileID: 1270154686371258703, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LODs.Array.data[1].renderers.Array.data[0].renderer
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1270154686371258703, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LODs.Array.data[2].renderers.Array.data[0].renderer
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1750915842032796396, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_Name
+      value: cloud_1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212925581419042433, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: b68a64caca02cbc4ab4e9f6b88ed316d, type: 2}
+    - target: {fileID: 7511083320534682346, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 28.722185
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -38.811604
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -33.82153
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.6553395
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7553345
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 98.109
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 9110504180177871159, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e, type: 3}
+    - {fileID: 2128102938237016118, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1750915842032796396, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 916606204}
+  m_SourcePrefab: {fileID: 100100000, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e, type: 3}
+--- !u!4 &916606202 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+    type: 3}
+  m_PrefabInstance: {fileID: 916606201}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &916606203 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1750915842032796396, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+    type: 3}
+  m_PrefabInstance: {fileID: 916606201}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &916606204
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 916606203}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.1, y: 1, z: 1.1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1001 &920006574
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 201037551}
+    m_Modifications:
+    - target: {fileID: 2384014560097971772, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: d7cd310ef634a034abab2d9806894dc9, type: 2}
+    - target: {fileID: 2653175844725749233, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2653175844725749233, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
+    - target: {fileID: 5541878569053640991, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_Name
+      value: cloud_small (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 37.93715
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -34.16265
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -40.213413
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.70469546
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.023644142
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7087042
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.02415966
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -3.874
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -269.676
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0.031
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 936855253423794581, guid: 0819da63da0b50042a487510d69c6550, type: 3}
+    - {fileID: 3124346702935965148, guid: 0819da63da0b50042a487510d69c6550, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0819da63da0b50042a487510d69c6550, type: 3}
+--- !u!4 &920006575 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+    type: 3}
+  m_PrefabInstance: {fileID: 920006574}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &921047186
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 921047187}
+  m_Layer: 0
+  m_Name: TowerAnchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &921047187
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 921047186}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.26, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 859200890}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &938219809
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 938219810}
+  - component: {fileID: 938219812}
+  - component: {fileID: 938219811}
+  m_Layer: 5
+  m_Name: CountDownPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &938219810
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 938219809}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1932304811}
+  m_Father: {fileID: 419628864}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 24, y: 125.061005}
+  m_SizeDelta: {x: 700.454, y: 948.578}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &938219811
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 938219809}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &938219812
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 938219809}
+  m_CullTransparentMesh: 1
+--- !u!1 &956063944
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 956063945}
+  - component: {fileID: 956063946}
+  m_Layer: 0
+  m_Name: JengaInputBootstrap
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &956063945
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 956063944}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -315.07175, y: -1221.0004, z: -8.96214}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 778223937}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &956063946
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 956063944}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 77614f6bab3a323429abffcfea60a8c3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &984699242
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 984699243}
+  - component: {fileID: 984699245}
+  - component: {fileID: 984699244}
+  m_Layer: 5
+  m_Name: Content
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &984699243
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 984699242}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1648873810}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0.000015258789, y: -35.64461}
+  m_SizeDelta: {x: 49.13, y: 0}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &984699244
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 984699242}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 0
+  m_VerticalFit: 2
+--- !u!114 &984699245
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 984699242}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 1
+  m_Spacing: 10
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!1 &993787422
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 993787423}
+  m_Layer: 0
+  m_Name: ----------Controller------------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &993787423
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 993787422}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 7.5236197, y: 5.509158, z: 5.135033}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1035653840
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1512531044}
+    m_Modifications:
+    - target: {fileID: 2384014560097971772, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: d7cd310ef634a034abab2d9806894dc9, type: 2}
+    - target: {fileID: 2653175844725749233, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2653175844725749233, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
+    - target: {fileID: 5541878569053640991, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_Name
+      value: cloud_small (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 37.93715
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -34.16265
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -40.213413
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.70469546
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.023644142
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7087042
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.02415966
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -3.874
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -269.676
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0.031
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 936855253423794581, guid: 0819da63da0b50042a487510d69c6550, type: 3}
+    - {fileID: 3124346702935965148, guid: 0819da63da0b50042a487510d69c6550, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0819da63da0b50042a487510d69c6550, type: 3}
+--- !u!4 &1035653841 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+    type: 3}
+  m_PrefabInstance: {fileID: 1035653840}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1067012250
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 669275690}
+    m_Modifications:
+    - target: {fileID: 3249078544740656951, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_Name
+      value: obj_BackGround (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 149.99998
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 150.00002
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 189.45715
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -232.12268
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -807.15344
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.261213
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.17311928
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.84264374
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.43789166
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -55.936
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 148.985
+      objectReference: {fileID: 0}
+    - target: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -6.457
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 53d824376eb53224785cb081a314aae8, type: 3}
+--- !u!4 &1067012251 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3844605209724090940, guid: 53d824376eb53224785cb081a314aae8,
+    type: 3}
+  m_PrefabInstance: {fileID: 1067012250}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1110847945
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1110847946}
+  m_Layer: 12
+  m_Name: Arena_1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1110847946
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110847945}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -59, y: 1.14, z: -49}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 363694453}
+  - {fileID: 757328113}
+  - {fileID: 201037551}
+  m_Father: {fileID: 748278360}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1272773744
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1272773745}
+  m_Layer: 0
+  m_Name: 1P
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1272773745
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1272773744}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -31.727148, y: 37.963623, z: 38.393406}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5028936980023486864}
+  - {fileID: 5459661996259786999}
+  - {fileID: 4012408829042898441}
+  - {fileID: 7858180841353959115}
+  - {fileID: 2468972318733881315}
+  - {fileID: 8110684590907827956}
+  - {fileID: 3276256650029411315}
+  - {fileID: 2921430010422554358}
+  - {fileID: 634983479888591}
+  - {fileID: 5383682927402170594}
+  - {fileID: 8195928822571489098}
+  - {fileID: 285159666094078403}
+  - {fileID: 3610911797514433177}
+  m_Father: {fileID: 748278361}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1288740885
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1217284196904556031, guid: bd6c411af2463804291825c789c17218,
+        type: 3}
+      propertyPath: gameTime
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 1217284196904556031, guid: bd6c411af2463804291825c789c17218,
+        type: 3}
+      propertyPath: remainingTime
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1217284196904556031, guid: bd6c411af2463804291825c789c17218,
+        type: 3}
+      propertyPath: mainMapSceneName
+      value: Test_LTHLobbyScene
+      objectReference: {fileID: 0}
+    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.5236197
+      objectReference: {fileID: 0}
+    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5.509158
+      objectReference: {fileID: 0}
+    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.135033
+      objectReference: {fileID: 0}
+    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5420769880533708589, guid: bd6c411af2463804291825c789c17218,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7053311724175509580, guid: bd6c411af2463804291825c789c17218,
+        type: 3}
+      propertyPath: m_Name
+      value: JengaGameManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 7053311724175509580, guid: bd6c411af2463804291825c789c17218,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bd6c411af2463804291825c789c17218, type: 3}
+--- !u!1001 &1333913872
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1512531044}
+    m_Modifications:
+    - target: {fileID: 479507496456824461, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 776784365096445319, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 998254667235688689, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1633060438778835276, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1693657314738859876, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2179198918834414145, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 1f009e6c9b3c12c4c90286f8520eeb3e, type: 2}
+    - target: {fileID: 2310601242580406089, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2512335187230525871, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2559005317696410539, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 1462aa91d4f61ba4cbce45f1466e7370, type: 2}
+    - target: {fileID: 3086694288264551852, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Name
+      value: CH004_Jeomboon_ST000 (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3086694288264551852, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3351456639516302159, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.77019006
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.77019006
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 30.237148
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -35.31265
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -41.963413
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.99836177
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.051711828
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.003997489
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.02415944
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -5.938
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.316
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -2.756
+      objectReference: {fileID: 0}
+    - target: {fileID: 4083934630649291340, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4525720165913689547, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Avatar
+      value: 
+      objectReference: {fileID: 9000000, guid: 1accc64b5557f4d4d907b94256d3901d, type: 3}
+    - target: {fileID: 4525720165913689547, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: 7870b3e7bb5457944a99ec759d3caddc, type: 2}
+    - target: {fileID: 4529109235228563054, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5271256582412779233, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5276360353308076930, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5316937281457807783, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5955275044844109399, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7608830386932149021, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7931025381836048110, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8296299598140844717, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8630629350457918488, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8731934752483395896, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0518a9970e535cd44b39e7070452963a, type: 3}
+--- !u!4 &1333913873 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+    type: 3}
+  m_PrefabInstance: {fileID: 1333913872}
+  m_PrefabAsset: {fileID: 0}
+--- !u!21 &1342515366
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0.024052067, g: 0.022535274, b: 0.9789449, a: 0.9755116}
+    - _WidthHeightRadius: {r: 1192.5742, g: 319.42212, b: 80, a: 0}
+  m_BuildTextureStacks: []
+--- !u!1 &1375761812
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1375761813}
+  - component: {fileID: 1375761816}
+  - component: {fileID: 1375761815}
+  - component: {fileID: 1375761814}
+  m_Layer: 5
+  m_Name: Option
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1375761813
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1375761812}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 419628864}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 982, y: -290}
+  m_SizeDelta: {x: 157.32251, y: 142.82007}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1375761814
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1375761812}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1375761815}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1375761815
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1375761812}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 7d7558e5ca1ea9f43824b4279dcc4609, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1375761816
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1375761812}
+  m_CullTransparentMesh: 1
+--- !u!1001 &1378479453
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 201037551}
+    m_Modifications:
+    - target: {fileID: 1393713133580456719, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_Name
+      value: Star (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1523659555437022603, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: -5801228030656462994, guid: 879532fb680028b48a18fd30681c81c0,
+        type: 3}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 117.707146
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -20.519367
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -198.15341
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9313001
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.36425287
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -42.723
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d, type: 3}
+--- !u!4 &1378479454 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1378479453}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1460646841
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1460646842}
+  m_Layer: 14
+  m_Name: Arena_3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1460646842
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1460646841}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -260, y: 1.14, z: -172}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 315647960}
+  - {fileID: 908722768}
+  - {fileID: 1512531044}
+  m_Father: {fileID: 748278360}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1512531043
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1512531044}
+  m_Layer: 0
+  m_Name: 4P
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1512531044
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1512531043}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -31.727148, y: 37.963623, z: 38.393406}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 704486633}
+  - {fileID: 766586353}
+  - {fileID: 2038611061}
+  - {fileID: 629855329}
+  - {fileID: 1999535299}
+  - {fileID: 476647886}
+  - {fileID: 2060763150}
+  - {fileID: 1630959624}
+  - {fileID: 1035653841}
+  - {fileID: 2108914976}
+  - {fileID: 701912562}
+  - {fileID: 486016270}
+  - {fileID: 1333913873}
+  m_Father: {fileID: 1460646842}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1522635646
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 201037551}
+    m_Modifications:
+    - target: {fileID: 479507496456824461, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 776784365096445319, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 998254667235688689, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1633060438778835276, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1693657314738859876, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2179198918834414145, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 1f009e6c9b3c12c4c90286f8520eeb3e, type: 2}
+    - target: {fileID: 2310601242580406089, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2512335187230525871, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2559005317696410539, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 1462aa91d4f61ba4cbce45f1466e7370, type: 2}
+    - target: {fileID: 3086694288264551852, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Name
+      value: CH004_Jeomboon_ST000 (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3086694288264551852, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3351456639516302159, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.77019006
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.77019006
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 30.237148
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -35.31265
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -41.963413
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.99836177
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.051711828
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.003997489
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.02415944
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -5.938
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.316
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -2.756
+      objectReference: {fileID: 0}
+    - target: {fileID: 4083934630649291340, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4525720165913689547, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Avatar
+      value: 
+      objectReference: {fileID: 9000000, guid: 1accc64b5557f4d4d907b94256d3901d, type: 3}
+    - target: {fileID: 4525720165913689547, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: 7870b3e7bb5457944a99ec759d3caddc, type: 2}
+    - target: {fileID: 4529109235228563054, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5271256582412779233, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5276360353308076930, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5316937281457807783, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5955275044844109399, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7608830386932149021, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7931025381836048110, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8296299598140844717, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8630629350457918488, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8731934752483395896, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0518a9970e535cd44b39e7070452963a, type: 3}
+--- !u!4 &1522635647 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+    type: 3}
+  m_PrefabInstance: {fileID: 1522635646}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1535448051
 GameObject:
@@ -9157,134 +9312,257 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1535448051}
   m_CullTransparentMesh: 1
---- !u!1 &1551513672
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1551513673}
-  m_Layer: 0
-  m_Name: -----------Map---------
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1551513673
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1551513672}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -225.13991, y: -66.52264, z: -275.13693}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1558434040
+--- !u!1001 &1545194025
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1368305595}
+    m_TransformParent: {fileID: 669275690}
     m_Modifications:
-    - target: {fileID: 329657563048967457, guid: 3c00ec95b49c1d546a217a587c86b37e,
+    - target: {fileID: 479507496456824461, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 776784365096445319, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 998254667235688689, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1633060438778835276, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1693657314738859876, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2179198918834414145, guid: 0518a9970e535cd44b39e7070452963a,
         type: 3}
       propertyPath: m_Mesh
       value: 
-      objectReference: {fileID: -5801228030656462994, guid: 879532fb680028b48a18fd30681c81c0,
+      objectReference: {fileID: 4300000, guid: 1f009e6c9b3c12c4c90286f8520eeb3e, type: 2}
+    - target: {fileID: 2310601242580406089, guid: 0518a9970e535cd44b39e7070452963a,
         type: 3}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.44314992
+      propertyPath: m_Layer
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+    - target: {fileID: 2512335187230525871, guid: 0518a9970e535cd44b39e7070452963a,
         type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.44315007
+      propertyPath: m_Layer
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+    - target: {fileID: 2559005317696410539, guid: 0518a9970e535cd44b39e7070452963a,
         type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -233.16061
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -36.929886
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -190.81961
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.947194
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.23615153
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.2079633
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.06170368
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -24.942
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -27.815
-      objectReference: {fileID: 0}
-    - target: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 13.724
-      objectReference: {fileID: 0}
-    - target: {fileID: 6411628229678914976, guid: 3c00ec95b49c1d546a217a587c86b37e,
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 1462aa91d4f61ba4cbce45f1466e7370, type: 2}
+    - target: {fileID: 3086694288264551852, guid: 0518a9970e535cd44b39e7070452963a,
         type: 3}
       propertyPath: m_Name
-      value: Star (8)
+      value: CH004_Jeomboon_ST000 (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3086694288264551852, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3351456639516302159, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.77019006
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.77019006
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 30.237148
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -35.31265
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -41.963413
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.99836177
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.051711828
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.003997489
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.02415944
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -5.938
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.316
+      objectReference: {fileID: 0}
+    - target: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -2.756
+      objectReference: {fileID: 0}
+    - target: {fileID: 4083934630649291340, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4525720165913689547, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Avatar
+      value: 
+      objectReference: {fileID: 9000000, guid: 1accc64b5557f4d4d907b94256d3901d, type: 3}
+    - target: {fileID: 4525720165913689547, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: 7870b3e7bb5457944a99ec759d3caddc, type: 2}
+    - target: {fileID: 4529109235228563054, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5271256582412779233, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5276360353308076930, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5316937281457807783, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5955275044844109399, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7608830386932149021, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7931025381836048110, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8296299598140844717, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8630629350457918488, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8731934752483395896, guid: 0518a9970e535cd44b39e7070452963a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 3c00ec95b49c1d546a217a587c86b37e, type: 3}
---- !u!4 &1558434041 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 0518a9970e535cd44b39e7070452963a, type: 3}
+--- !u!4 &1545194026 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 1363601182614563997, guid: 3c00ec95b49c1d546a217a587c86b37e,
+  m_CorrespondingSourceObject: {fileID: 3476697478234085570, guid: 0518a9970e535cd44b39e7070452963a,
     type: 3}
-  m_PrefabInstance: {fileID: 1558434040}
+  m_PrefabInstance: {fileID: 1545194025}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1581396040
+--- !u!21 &1601309345
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
+    - _WidthHeightRadius: {r: 149.651, g: 51.939, b: 40, a: 0}
+  m_BuildTextureStacks: []
+--- !u!1001 &1608619355
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 344144929}
+    m_TransformParent: {fileID: 201037551}
     m_Modifications:
     - target: {fileID: 614895130769055622, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
@@ -9314,22 +9592,22 @@ PrefabInstance:
     - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -140.55606
+      value: 30.021023
       objectReference: {fileID: 0}
     - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -34.87262
+      value: -35.87265
       objectReference: {fileID: 0}
     - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -129.31067
+      value: -41.337597
       objectReference: {fileID: 0}
     - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.061361626
+      value: 0.020058993
       objectReference: {fileID: 0}
     - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
@@ -9339,7 +9617,7 @@ PrefabInstance:
     - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.99811566
+      value: -0.9997988
       objectReference: {fileID: 0}
     - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
@@ -9354,7 +9632,7 @@ PrefabInstance:
     - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: -172.964
+      value: -177.701
       objectReference: {fileID: 0}
     - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
@@ -9364,7 +9642,7 @@ PrefabInstance:
     - target: {fileID: 6508736201795955369, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
       propertyPath: m_Name
-      value: cloud_small (4)
+      value: cloud_small (2)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
@@ -9373,182 +9651,213 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 14d72a544b3ee7e49a3e59a75ff170ec, type: 3}
---- !u!4 &1581396041 stripped
+--- !u!4 &1608619356 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
     type: 3}
-  m_PrefabInstance: {fileID: 1581396040}
+  m_PrefabInstance: {fileID: 1608619355}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1588409007
+--- !u!1001 &1616517816
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 344144929}
+    m_TransformParent: {fileID: 201037551}
     m_Modifications:
-    - target: {fileID: 2384014560097971772, guid: 0819da63da0b50042a487510d69c6550,
+    - target: {fileID: 100539952889884493, guid: 03e21b53685994d43a092c2d1b9c6a84,
         type: 3}
       propertyPath: m_Mesh
       value: 
-      objectReference: {fileID: 4300000, guid: d7cd310ef634a034abab2d9806894dc9, type: 2}
-    - target: {fileID: 2653175844725749233, guid: 0819da63da0b50042a487510d69c6550,
+      objectReference: {fileID: 4300000, guid: 205163206283e7a40838be91cdc4eee7, type: 2}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.43432003
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.43431997
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 31.18511
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -36.62358
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -33.41142
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9524369
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.09550917
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.28929576
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.007060775
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -10.244
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -34.151
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 4.004
+      objectReference: {fileID: 0}
+    - target: {fileID: 5405934403816150963, guid: 03e21b53685994d43a092c2d1b9c6a84,
         type: 3}
       propertyPath: m_CastShadows
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2653175844725749233, guid: 0819da63da0b50042a487510d69c6550,
+    - target: {fileID: 5405934403816150963, guid: 03e21b53685994d43a092c2d1b9c6a84,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
-    - target: {fileID: 5541878569053640991, guid: 0819da63da0b50042a487510d69c6550,
+    - target: {fileID: 7581750188737525860, guid: 03e21b53685994d43a092c2d1b9c6a84,
         type: 3}
       propertyPath: m_Name
-      value: cloud_small (5)
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -132.5741
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -33.16263
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -128.84406
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.67480403
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.02262546
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.7372224
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.025116166
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -3.874
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -264.939
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0.031
+      value: cloud_medium (1)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
-    - {fileID: 936855253423794581, guid: 0819da63da0b50042a487510d69c6550, type: 3}
-    - {fileID: 3124346702935965148, guid: 0819da63da0b50042a487510d69c6550, type: 3}
+    - {fileID: 7186054671757280169, guid: 03e21b53685994d43a092c2d1b9c6a84, type: 3}
+    - {fileID: 7084152554214074933, guid: 03e21b53685994d43a092c2d1b9c6a84, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0819da63da0b50042a487510d69c6550, type: 3}
---- !u!4 &1588409008 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 03e21b53685994d43a092c2d1b9c6a84, type: 3}
+--- !u!4 &1616517817 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
+  m_CorrespondingSourceObject: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
     type: 3}
-  m_PrefabInstance: {fileID: 1588409007}
+  m_PrefabInstance: {fileID: 1616517816}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1626050111
+--- !u!1001 &1630959623
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1368305595}
+    m_TransformParent: {fileID: 1512531044}
     m_Modifications:
-    - target: {fileID: 2202635855084851171, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+    - target: {fileID: 614895130769055622, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
-      propertyPath: m_Name
-      value: Star (9)
-      objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
+    - target: {fileID: 4603879714568064926, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: d7cd310ef634a034abab2d9806894dc9, type: 2}
+    - target: {fileID: 5066022526432343303, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -166.83636
+      value: -0.26985377
       objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+    - target: {fileID: 5066022526432343303, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -39.019333
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+    - target: {fileID: 5066022526432343303, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -274.41315
+      value: 0.48957014
       objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 30.021023
+      objectReference: {fileID: 0}
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -35.87265
+      objectReference: {fileID: 0}
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -41.337597
+      objectReference: {fileID: 0}
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9455583
+      value: 0.020058993
       objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.32545283
+      value: -0.9997988
       objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: -37.986
+      value: -177.701
       objectReference: {fileID: 0}
-    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4514368027778736621, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+    - target: {fileID: 6508736201795955369, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
         type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: -5801228030656462994, guid: 879532fb680028b48a18fd30681c81c0,
-        type: 3}
+      propertyPath: m_Name
+      value: cloud_small (2)
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
+    m_RemovedGameObjects:
+    - {fileID: 3807266887916899018, guid: 14d72a544b3ee7e49a3e59a75ff170ec, type: 3}
+    - {fileID: 1027792874845127237, guid: 14d72a544b3ee7e49a3e59a75ff170ec, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 43bf369892f7f7d4cb1dc7249773b8c7, type: 3}
---- !u!4 &1626050112 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 14d72a544b3ee7e49a3e59a75ff170ec, type: 3}
+--- !u!4 &1630959624 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+  m_CorrespondingSourceObject: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
     type: 3}
-  m_PrefabInstance: {fileID: 1626050111}
+  m_PrefabInstance: {fileID: 1630959623}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1637472399
 GameObject:
@@ -9791,248 +10100,417 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
---- !u!1001 &1704368445
+--- !u!1001 &1705364805
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 344144929}
+    m_TransformParent: {fileID: 669275690}
     m_Modifications:
-    - target: {fileID: 100539952889884493, guid: 03e21b53685994d43a092c2d1b9c6a84,
+    - target: {fileID: 2202635855084851171, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 205163206283e7a40838be91cdc4eee7, type: 2}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.43432012
+      propertyPath: m_Name
+      value: Star
       objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.43431994
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -138.74136
+      value: 101.957146
       objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -35.62355
+      value: -40.019367
       objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -121.50775
+      value: -113.95323
       objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.96357924
+      value: 0.9313001
       objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.09513574
+      value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.24968626
+      value: -0.36425287
       objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.0110019585
+      value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -10.244
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -29.413
-      objectReference: {fileID: 0}
-    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 4.004
-      objectReference: {fileID: 0}
-    - target: {fileID: 5405934403816150963, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_CastShadows
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5405934403816150963, guid: 03e21b53685994d43a092c2d1b9c6a84,
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
-    - target: {fileID: 7581750188737525860, guid: 03e21b53685994d43a092c2d1b9c6a84,
-        type: 3}
-      propertyPath: m_Name
-      value: cloud_medium (4)
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -42.723
       objectReference: {fileID: 0}
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4514368027778736621, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: -5801228030656462994, guid: 879532fb680028b48a18fd30681c81c0,
+        type: 3}
     m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 7186054671757280169, guid: 03e21b53685994d43a092c2d1b9c6a84, type: 3}
-    - {fileID: 7084152554214074933, guid: 03e21b53685994d43a092c2d1b9c6a84, type: 3}
+    m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 03e21b53685994d43a092c2d1b9c6a84, type: 3}
---- !u!4 &1704368446 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 43bf369892f7f7d4cb1dc7249773b8c7, type: 3}
+--- !u!4 &1705364806 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+  m_CorrespondingSourceObject: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
     type: 3}
-  m_PrefabInstance: {fileID: 1704368445}
+  m_PrefabInstance: {fileID: 1705364805}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1728579986
+--- !u!1001 &1733294412
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1368305595}
+    m_TransformParent: {fileID: 669275690}
     m_Modifications:
-    - target: {fileID: 1528725312502566776, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+    - target: {fileID: 1270154686371258703, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LODs.Array.data[1].renderers.Array.data[0].renderer
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1270154686371258703, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LODs.Array.data[2].renderers.Array.data[0].renderer
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1750915842032796396, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_Name
+      value: cloud_1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212925581419042433, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: b68a64caca02cbc4ab4e9f6b88ed316d, type: 2}
+    - target: {fileID: 7511083320534682346, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.1799997
+      value: 15
       objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.1799996
-      objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.1799995
+      value: 15
       objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -224.42899
+      value: 28.722185
       objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -27.125687
+      value: -38.811604
       objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -217.9072
+      value: -33.82153
       objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.99953806
+      value: 0.6553395
       objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.016289156
+      value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.022152629
+      value: 0.7553345
       objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.012949174
+      value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 1.833
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 2.564
+      value: 98.109
       objectReference: {fileID: 0}
-    - target: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 1.525
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7349414926691905503, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_Name
-      value: cloud_medium (5)
-      objectReference: {fileID: 0}
-    - target: {fileID: 7859370079127710536, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 205163206283e7a40838be91cdc4eee7, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects:
-    - {fileID: 8737101222051999724, guid: 5afb8b4ced538e949ba0d67073aa9e5c, type: 3}
-    - {fileID: 506987933308232340, guid: 5afb8b4ced538e949ba0d67073aa9e5c, type: 3}
+    - {fileID: 9110504180177871159, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e, type: 3}
+    - {fileID: 2128102938237016118, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e, type: 3}
     m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 5afb8b4ced538e949ba0d67073aa9e5c, type: 3}
---- !u!4 &1728579987 stripped
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1750915842032796396, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1733294415}
+  m_SourcePrefab: {fileID: 100100000, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e, type: 3}
+--- !u!4 &1733294413 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4863948022531443154, guid: 5afb8b4ced538e949ba0d67073aa9e5c,
+  m_CorrespondingSourceObject: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
     type: 3}
-  m_PrefabInstance: {fileID: 1728579986}
+  m_PrefabInstance: {fileID: 1733294412}
   m_PrefabAsset: {fileID: 0}
---- !u!21 &1770409293
-Material:
-  serializedVersion: 8
+--- !u!1 &1733294414 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1750915842032796396, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1733294412}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &1733294415
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
+  m_GameObject: {fileID: 1733294414}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.1, y: 1, z: 1.1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1001 &1747515292
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
     serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
-    - _WidthHeightRadius: {r: 149.651, g: 51.939, b: 40, a: 0}
-  m_BuildTextureStacks: []
+    m_TransformParent: {fileID: 669275690}
+    m_Modifications:
+    - target: {fileID: 205199232430197985, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 1462aa91d4f61ba4cbce45f1466e7370, type: 2}
+    - target: {fileID: 693171626104918311, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 949525825426924918, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140083441428025614, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1203845097954375624, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1601048368097342954, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 34.973694
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -38.12815
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -36.690258
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.8411365
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.030746298
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.53780264
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.048088007
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -5.938
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -65.045
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -2.756
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341286143228779244, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3457535365598932673, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4059265812233729036, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4091603727724860672, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Name
+      value: CH004_Jeomboon_ST000
+      objectReference: {fileID: 0}
+    - target: {fileID: 4091603727724860672, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4110911525456033966, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4235584798692782408, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4311174686238707878, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Avatar
+      value: 
+      objectReference: {fileID: 9000000, guid: 1accc64b5557f4d4d907b94256d3901d, type: 3}
+    - target: {fileID: 4311174686238707878, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: 7870b3e7bb5457944a99ec759d3caddc, type: 2}
+    - target: {fileID: 4323501119090150739, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4340203541418652595, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 1f009e6c9b3c12c4c90286f8520eeb3e, type: 2}
+    - target: {fileID: 4342870901537235461, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5871282379063428266, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5919040412902176434, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6011502035705782187, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6484597149563290023, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6982086428817300633, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7574369119542141112, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8244057176046662537, guid: e877e31156c607e46a5319bffdd8e6a6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e877e31156c607e46a5319bffdd8e6a6, type: 3}
+--- !u!4 &1747515293 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3122048517107470932, guid: e877e31156c607e46a5319bffdd8e6a6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1747515292}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1800503796
 GameObject:
   m_ObjectHideFlags: 0
@@ -10585,107 +11063,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1867122145}
   m_CullTransparentMesh: 1
---- !u!1001 &1907386681
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1368305595}
-    m_Modifications:
-    - target: {fileID: 614895130769055622, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
-    - target: {fileID: 4603879714568064926, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: d7cd310ef634a034abab2d9806894dc9, type: 2}
-    - target: {fileID: 5066022526432343303, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.26985377
-      objectReference: {fileID: 0}
-    - target: {fileID: 5066022526432343303, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5066022526432343303, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.48957014
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -232.52972
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -34.87262
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -196.10464
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.061361626
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.99811566
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -172.964
-      objectReference: {fileID: 0}
-    - target: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6508736201795955369, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-        type: 3}
-      propertyPath: m_Name
-      value: cloud_small (6)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 3807266887916899018, guid: 14d72a544b3ee7e49a3e59a75ff170ec, type: 3}
-    - {fileID: 1027792874845127237, guid: 14d72a544b3ee7e49a3e59a75ff170ec, type: 3}
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 14d72a544b3ee7e49a3e59a75ff170ec, type: 3}
---- !u!4 &1907386682 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5527754874099845600, guid: 14d72a544b3ee7e49a3e59a75ff170ec,
-    type: 3}
-  m_PrefabInstance: {fileID: 1907386681}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1932304810
 GameObject:
   m_ObjectHideFlags: 0
@@ -11003,104 +11380,13 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1979129519
+--- !u!1001 &1992865381
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1368305595}
-    m_Modifications:
-    - target: {fileID: 2384014560097971772, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: d7cd310ef634a034abab2d9806894dc9, type: 2}
-    - target: {fileID: 2653175844725749233, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2653175844725749233, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
-    - target: {fileID: 5541878569053640991, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_Name
-      value: cloud_small (7)
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -224.54776
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -33.16263
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -195.63803
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.67480403
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.02262546
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.7372224
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.025116166
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -3.874
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -264.939
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0.031
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 936855253423794581, guid: 0819da63da0b50042a487510d69c6550, type: 3}
-    - {fileID: 3124346702935965148, guid: 0819da63da0b50042a487510d69c6550, type: 3}
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0819da63da0b50042a487510d69c6550, type: 3}
---- !u!4 &1979129520 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-    type: 3}
-  m_PrefabInstance: {fileID: 1979129519}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &2026746948
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 33146209}
+    m_TransformParent: {fileID: 201037551}
     m_Modifications:
     - target: {fileID: 2202635855084851171, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
@@ -11110,22 +11396,22 @@ PrefabInstance:
     - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 28.387299
+      value: 101.957146
       objectReference: {fileID: 0}
     - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -39.019333
+      value: -40.019367
       objectReference: {fileID: 0}
     - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -149.1192
+      value: -113.95323
       objectReference: {fileID: 0}
     - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9455583
+      value: 0.9313001
       objectReference: {fileID: 0}
     - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
@@ -11135,7 +11421,7 @@ PrefabInstance:
     - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.32545283
+      value: -0.36425287
       objectReference: {fileID: 0}
     - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
@@ -11150,7 +11436,7 @@ PrefabInstance:
     - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: -37.986
+      value: -42.723
       objectReference: {fileID: 0}
     - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
         type: 3}
@@ -11168,110 +11454,19 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 43bf369892f7f7d4cb1dc7249773b8c7, type: 3}
---- !u!4 &2026746949 stripped
+--- !u!4 &1992865382 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
     type: 3}
-  m_PrefabInstance: {fileID: 2026746948}
+  m_PrefabInstance: {fileID: 1992865381}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &2028523225
+--- !u!1001 &1999535298
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 33146209}
-    m_Modifications:
-    - target: {fileID: 2384014560097971772, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: d7cd310ef634a034abab2d9806894dc9, type: 2}
-    - target: {fileID: 2653175844725749233, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_CastShadows
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2653175844725749233, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
-    - target: {fileID: 5541878569053640991, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_Name
-      value: cloud_small (3)
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -29.324095
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -33.16263
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -70.344055
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.67480403
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.02262546
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.7372224
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.025116166
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -3.874
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -264.939
-      objectReference: {fileID: 0}
-    - target: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0.031
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 936855253423794581, guid: 0819da63da0b50042a487510d69c6550, type: 3}
-    - {fileID: 3124346702935965148, guid: 0819da63da0b50042a487510d69c6550, type: 3}
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0819da63da0b50042a487510d69c6550, type: 3}
---- !u!4 &2028523226 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6545568490761462258, guid: 0819da63da0b50042a487510d69c6550,
-    type: 3}
-  m_PrefabInstance: {fileID: 2028523225}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &2101809642
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 33146209}
+    m_TransformParent: {fileID: 1512531044}
     m_Modifications:
     - target: {fileID: 5651446509498788021, guid: 9cfa9c37b98744a449e7c0127f470a30,
         type: 3}
@@ -11281,22 +11476,22 @@ PrefabInstance:
     - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -6.539549
+      value: 72.707146
       objectReference: {fileID: 0}
     - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -67.01933
+      value: -68.01936
       objectReference: {fileID: 0}
     - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -216.41461
+      value: -183.90341
       objectReference: {fileID: 0}
     - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9455583
+      value: 0.9313001
       objectReference: {fileID: 0}
     - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
         type: 3}
@@ -11306,7 +11501,7 @@ PrefabInstance:
     - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.32545283
+      value: -0.36425287
       objectReference: {fileID: 0}
     - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
         type: 3}
@@ -11321,7 +11516,7 @@ PrefabInstance:
     - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: -37.986
+      value: -42.723
       objectReference: {fileID: 0}
     - target: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
         type: 3}
@@ -11339,11 +11534,409 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9cfa9c37b98744a449e7c0127f470a30, type: 3}
---- !u!4 &2101809643 stripped
+--- !u!4 &1999535299 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6872409261307817753, guid: 9cfa9c37b98744a449e7c0127f470a30,
     type: 3}
-  m_PrefabInstance: {fileID: 2101809642}
+  m_PrefabInstance: {fileID: 1999535298}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2038611060
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1512531044}
+    m_Modifications:
+    - target: {fileID: 2202635855084851171, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+        type: 3}
+      propertyPath: m_Name
+      value: Star
+      objectReference: {fileID: 0}
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 101.957146
+      objectReference: {fileID: 0}
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -40.019367
+      objectReference: {fileID: 0}
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -113.95323
+      objectReference: {fileID: 0}
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9313001
+      objectReference: {fileID: 0}
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.36425287
+      objectReference: {fileID: 0}
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -42.723
+      objectReference: {fileID: 0}
+    - target: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4514368027778736621, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: -5801228030656462994, guid: 879532fb680028b48a18fd30681c81c0,
+        type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 43bf369892f7f7d4cb1dc7249773b8c7, type: 3}
+--- !u!4 &2038611061 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2248807950918231410, guid: 43bf369892f7f7d4cb1dc7249773b8c7,
+    type: 3}
+  m_PrefabInstance: {fileID: 2038611060}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2060763149
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1512531044}
+    m_Modifications:
+    - target: {fileID: 1270154686371258703, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LODs.Array.data[1].renderers.Array.data[0].renderer
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1270154686371258703, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LODs.Array.data[2].renderers.Array.data[0].renderer
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1750915842032796396, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_Name
+      value: cloud_1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212925581419042433, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: b68a64caca02cbc4ab4e9f6b88ed316d, type: 2}
+    - target: {fileID: 7511083320534682346, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 28.722185
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -38.811604
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -33.82153
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.6553395
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7553345
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 98.109
+      objectReference: {fileID: 0}
+    - target: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 9110504180177871159, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e, type: 3}
+    - {fileID: 2128102938237016118, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1750915842032796396, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2060763152}
+  m_SourcePrefab: {fileID: 100100000, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e, type: 3}
+--- !u!4 &2060763150 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7660254191366298137, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+    type: 3}
+  m_PrefabInstance: {fileID: 2060763149}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2060763151 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1750915842032796396, guid: 39f3c2b9bbb0f4244afff44a2d9cf10e,
+    type: 3}
+  m_PrefabInstance: {fileID: 2060763149}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &2060763152
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2060763151}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.1, y: 1, z: 1.1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1001 &2100874807
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 669275690}
+    m_Modifications:
+    - target: {fileID: 1393713133580456719, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_Name
+      value: Star (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1523659555437022603, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: -5801228030656462994, guid: 879532fb680028b48a18fd30681c81c0,
+        type: 3}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 117.707146
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -20.519367
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -198.15341
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9313001
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.36425287
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -42.723
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d, type: 3}
+--- !u!4 &2100874808 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8555866251022244765, guid: 4cccdfbeeb3ad1f49ac64d58da1c612d,
+    type: 3}
+  m_PrefabInstance: {fileID: 2100874807}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2108914975
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1512531044}
+    m_Modifications:
+    - target: {fileID: 100539952889884493, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 205163206283e7a40838be91cdc4eee7, type: 2}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.43432003
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.43431997
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 31.18511
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -36.62358
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -33.41142
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9524369
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.09550917
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.28929576
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.007060775
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -10.244
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -34.151
+      objectReference: {fileID: 0}
+    - target: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 4.004
+      objectReference: {fileID: 0}
+    - target: {fileID: 5405934403816150963, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5405934403816150963, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 861dce2005b2e4f4b8b46361d7741c72, type: 2}
+    - target: {fileID: 7581750188737525860, guid: 03e21b53685994d43a092c2d1b9c6a84,
+        type: 3}
+      propertyPath: m_Name
+      value: cloud_medium (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 7186054671757280169, guid: 03e21b53685994d43a092c2d1b9c6a84, type: 3}
+    - {fileID: 7084152554214074933, guid: 03e21b53685994d43a092c2d1b9c6a84, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 03e21b53685994d43a092c2d1b9c6a84, type: 3}
+--- !u!4 &2108914976 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 595284342494141741, guid: 03e21b53685994d43a092c2d1b9c6a84,
+    type: 3}
+  m_PrefabInstance: {fileID: 2108914975}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &2128988681
 GameObject:
@@ -13879,11 +14472,6 @@ SceneRoots:
   - {fileID: 392257178}
   - {fileID: 410087041}
   - {fileID: 832575519}
-  - {fileID: 1551513673}
-  - {fileID: 1272773745}
-  - {fileID: 33146209}
-  - {fileID: 344144929}
-  - {fileID: 1368305595}
   - {fileID: 993787423}
   - {fileID: 586440524}
   - {fileID: 1937771134}


### PR DESCRIPTION
# 🧑‍💻 PR

## 🔗 관련 이슈
- 수행한 작업과 관련 작업 번호를 작성해주세요 
- Related to: #70
- Related to: #71
- Related to: #84


## 💻 버그 해결방법

### 💡 해결방법
- Related to: #70 
모든 플레이어가 같은 각도의 시야를 볼 수 있도록 수정

- Related to: #71 
     - 게임의 “시작 신호”가 두 가지 방식으로 동시에 전달되고 있었음 (서버에서 전파되는 게임 상태, 별도의 동기화 신호)
     - 이 두 신호가 타이밍에 따라 엇갈리면 일부 기기에서 "게임이 시작됐다"는 표시를 못 받아 타이머도 안 켜지고, 결국 게임이 멈추는 문제 발생
     - 해결방안
        - 게임 시작 신호를 한 가지 방식(공식 기록된 값)으로만 전달.
        - 기록되는 값은 숫자 형식을 하나(int)로 통일해서 모든 기기가 동일하게 인식.
        - 늦게 접속하거나 신호를 놓친 기기도 게임 방에 기록된 시작 시간을 다시 확인해서 따라잡을 수 있도록 안전장치(자동 보정 기능)를 유지.

- Related to: #84 
      - 게임 시작 직후, 각 클라이언트(플레이어의 기기)에서 타이머를 표시하는 시점이 달라서 생긴 문제
      - 해결방안
            - 타이머는 게임 방에 기록된 '공식 시간'만 보여주도록 고정
            - 게임 시작 전 카운트다운 동안은 타이머를 숨기고, 카운트다운이 끝난 뒤에만 타이머가 보이도록 수정

### ✔️ 버그 체크리스트
- [ ] 추가로 수정이 필요함
- [x] 수정 완료
- [ ] QA 테스트 통과

## ✅ PR 체크리스트
- [x] 빌드 오류 없음
- [x] 기능 정상 작동 확인
- [x] 커밋 메시지 규칙 준수
- [x] Scene 충돌 없음