### PR TITLE
[Fix] 젠가 확대 RT 비율 조정

### DIFF
--- a/Assets/LTH/LTH_Prefabs/TowerFocus.renderTexture
+++ b/Assets/LTH/LTH_Prefabs/TowerFocus.renderTexture
@@ -18,11 +18,11 @@ RenderTexture:
   m_Height: 1024
   m_AntiAliasing: 1
   m_MipCount: -1
-  m_DepthStencilFormat: 94
-  m_ColorFormat: 8
+  m_DepthStencilFormat: 90
+  m_ColorFormat: 4
   m_MipMap: 0
   m_GenerateMips: 1
-  m_SRGB: 0
+  m_SRGB: 1
   m_UseDynamicScale: 0
   m_BindMS: 0
   m_EnableCompatibleFormat: 1

--- a/Assets/LTH/LTH_Scenes/Test_LTHScene.unity
+++ b/Assets/LTH/LTH_Scenes/Test_LTHScene.unity
@@ -467,6 +467,139 @@ MonoBehaviour:
   m_PointerBehavior: 0
   m_CursorLockBehavior: 0
   m_ScrollDeltaPerTick: 6
+--- !u!1001 &575390049
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 382.281
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 390.114
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 531.16956
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 838.30664
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3380019038747022192, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_Name
+      value: Unimo_RTDisplay
+      objectReference: {fileID: 0}
+    - target: {fileID: 7396686963220418033, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7396686963220418033, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7396686963220418033, guid: 658f3813a0c86d341878bb3628d1b24f,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 658f3813a0c86d341878bb3628d1b24f, type: 3}
 --- !u!1 &884299260
 GameObject:
   m_ObjectHideFlags: 0
@@ -581,11 +714,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1967320850}
     m_Modifications:
-    - target: {fileID: 1129074200960674102, guid: cf3cc35964ca9454982372dd983d39b5,
-        type: 3}
-      propertyPath: m_text
-      value: "Tip \n"
-      objectReference: {fileID: 0}
     - target: {fileID: 5469648193770635147, guid: cf3cc35964ca9454982372dd983d39b5,
         type: 3}
       propertyPath: m_Name
@@ -691,32 +819,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8437802438891909409, guid: cf3cc35964ca9454982372dd983d39b5,
-        type: 3}
-      propertyPath: m_text
-      value: "\uC637\uC7A5\uC5D0\uC11C \uC6D0\uD558\uB294 \uC720\uB2C8\uBAA8\uB97C
-        \uC120\uD0DD\uD574\uBCF4\uC138\uC694"
-      objectReference: {fileID: 0}
-    - target: {fileID: 8437802438891909409, guid: cf3cc35964ca9454982372dd983d39b5,
-        type: 3}
-      propertyPath: m_fontColor.b
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8437802438891909409, guid: cf3cc35964ca9454982372dd983d39b5,
-        type: 3}
-      propertyPath: m_fontColor.g
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8437802438891909409, guid: cf3cc35964ca9454982372dd983d39b5,
-        type: 3}
-      propertyPath: m_fontColor.r
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8437802438891909409, guid: cf3cc35964ca9454982372dd983d39b5,
-        type: 3}
-      propertyPath: m_fontColor32.rgba
-      value: 4278190080
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -728,6 +830,139 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1244015868}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1500446471
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 382.281
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 390.114
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 531.16956
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 838.30664
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 597881506261649577, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3380019038747022192, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_Name
+      value: Unimo_RTDisplay 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7396686963220418033, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7396686963220418033, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7396686963220418033, guid: f61a8b3cfcc1fb7479287411ec8fb801,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f61a8b3cfcc1fb7479287411ec8fb801, type: 3}
 --- !u!1 &1967320846
 GameObject:
   m_ObjectHideFlags: 0
@@ -839,3 +1074,5 @@ SceneRoots:
   - {fileID: 884299264}
   - {fileID: 355478252}
   - {fileID: 1967320850}
+  - {fileID: 575390049}
+  - {fileID: 1500446471}

--- a/Assets/LTH/LTH_Scripts/Loadings/UnimoRTBBinder.cs
+++ b/Assets/LTH/LTH_Scripts/Loadings/UnimoRTBBinder.cs
@@ -23,7 +23,8 @@ public class UnimoRTBBinder : MonoBehaviour
         _rt = new RenderTexture(size, size, 16, RenderTextureFormat.ARGB32)
         {
             useMipMap = false,
-            antiAliasing = 1
+            antiAliasing = 1,
+            depthStencilFormat = UnityEngine.Experimental.Rendering.GraphicsFormat.D16_UNorm,
         };
         _rt.Create();
 

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaFocusOverlay/RawImageClickForwarder.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaFocusOverlay/RawImageClickForwarder.cs
@@ -54,7 +54,10 @@ public class RawImageClickForwarder : MonoBehaviour, IPointerClickHandler, IPoin
         foreach (var h in hits)
         {
             var proxy = h.collider.GetComponent<FaceHitProxy>();
-            if (proxy == null) continue;
+            if (proxy == null)
+            {
+                continue;
+            }
 
             var block = proxy.owner;
 
@@ -100,16 +103,16 @@ public class RawImageClickForwarder : MonoBehaviour, IPointerClickHandler, IPoin
     private bool PrepareRay(PointerEventData eventData, out Ray ray)
     {
         ray = default;
-        if (overlay == null || !overlay.IsActive) return false;
+        if (overlay == null || !overlay.IsActive)
+        {
+            return false;
+        }
 
         var cam = overlay.TowerCam;
-        if (cam == null) return false;
-
-        //if (jengaMask == 0)
-        //{
-        //    jengaMask = cam.cullingMask;
-        //    if (jengaMask == 0) return false; // 그래도 0이면 클릭 불가
-        //}
+        if (cam == null)
+        {
+            return false;
+        }
 
         if (!RectTransformUtility.ScreenPointToLocalPointInRectangle(
             rt, eventData.position, eventData.pressEventCamera, out var local))
@@ -140,10 +143,15 @@ public class RawImageClickForwarder : MonoBehaviour, IPointerClickHandler, IPoin
     private Rect GetDrawRectLocal(RawImage img)
     {
         var r = rt.rect;
-        if (img.texture == null || !compensateLetterbox) return r;
+
+        if (img.texture == null || !compensateLetterbox)
+        {
+            return r;
+        }
 
         float texAspect = (float)img.texture.width / img.texture.height;
         float rectAspect = r.size.x / r.size.y;
+
         if (Mathf.Approximately(texAspect, rectAspect)) return r;
 
         if (texAspect > rectAspect)

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaFocusOverlay/TowerFocusOverlay.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaFocusOverlay/TowerFocusOverlay.cs
@@ -94,7 +94,6 @@ public class TowerFocusOverlay : MonoBehaviour
 
     void OnEnable()
     {
-        // 오버레이가 늦게 켜졌을 때도 안전하게 마스크/RT 보정
         EnsureCameraAndTexture();
         if (arenaMask == 0 && JengaTowerManager.Instance != null)
         {
@@ -107,7 +106,7 @@ public class TowerFocusOverlay : MonoBehaviour
     {
         if (!active || _boundTower == null || towerCam == null) return;
 
-        Reframe(); // 클릭한 면(_faceLocalDir) 기준으로 리프레임
+        Reframe();
     }
 
 

--- a/Assets/Resources/Prefabs/UI/Popup/UI_Loading.prefab
+++ b/Assets/Resources/Prefabs/UI/Popup/UI_Loading.prefab
@@ -291,7 +291,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 
+  m_text: "\uC637\uC7A5\uC5D0\uC11C \uC6D0\uD558\uB294 \uC720\uB2C8\uBAA8\uB97C \uC120\uD0DD\uD574\uBCF4\uC138\uC694"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 263a5f6c8c323c84e9bd6ede05411f99, type: 2}
   m_sharedMaterial: {fileID: -363288562218260364, guid: 263a5f6c8c323c84e9bd6ede05411f99,
@@ -301,8 +301,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -431,8 +431,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 12, y: 222}
-  m_SizeDelta: {x: 1696.1548, y: 1375.8475}
+  m_AnchoredPosition: {x: 26, y: 143}
+  m_SizeDelta: {x: 1500, y: 1500}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1725431843637921638
 GameObject:
@@ -826,7 +826,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "\uB85C\uB529 \uC911..."
+  m_text: "\uB85C\uB529\uC911..."
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 263a5f6c8c323c84e9bd6ede05411f99, type: 2}
   m_sharedMaterial: {fileID: -363288562218260364, guid: 263a5f6c8c323c84e9bd6ede05411f99,

--- a/Assets/Scenes/MiniGameJengaScene.unity
+++ b/Assets/Scenes/MiniGameJengaScene.unity
@@ -337,46 +337,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 27118689}
   m_CullTransparentMesh: 1
---- !u!21 &27643673
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 0.99999994, a: 1}
-    - _WidthHeightRadius: {r: 1275.0493, g: 849.3999, b: 80, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1 &29469105
 GameObject:
   m_ObjectHideFlags: 0
@@ -1723,8 +1683,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 12.719971, y: 458.50574}
-  m_SizeDelta: {x: 744.56, y: 447.0115}
+  m_AnchoredPosition: {x: 9, y: 497}
+  m_SizeDelta: {x: 477, y: 477}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &254962754
 MonoBehaviour:
@@ -1778,7 +1738,7 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 65536
   compensateLetterbox: 1
-  ignoreClicksOutsideDraw: 1
+  ignoreClicksOutsideDraw: 0
   rayDistance: 100
 --- !u!1 &290534251
 GameObject:
@@ -2863,6 +2823,46 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 371573362}
   m_PrefabAsset: {fileID: 0}
+--- !u!21 &385330570
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 0.99999994, a: 1}
+    - _WidthHeightRadius: {r: 1275.0493, g: 849.3999, b: 80, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1 &392257174
 GameObject:
   m_ObjectHideFlags: 0
@@ -4948,46 +4948,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 486016269}
   m_PrefabAsset: {fileID: 0}
---- !u!21 &510692240
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0.024052067, g: 0.022535274, b: 0.9789449, a: 0.9755116}
-    - _WidthHeightRadius: {r: 1192.5742, g: 319.42212, b: 80, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1 &545133229
 GameObject:
   m_ObjectHideFlags: 0
@@ -5034,6 +4994,46 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!21 &578149571
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
+    - _WidthHeightRadius: {r: 149.651, g: 51.939, b: 40, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1 &580941682
 GameObject:
   m_ObjectHideFlags: 0
@@ -7029,46 +7029,6 @@ Transform:
   - {fileID: 956063945}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!21 &794713411
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 0.99999994, a: 1}
-    - _WidthHeightRadius: {r: 1275.0493, g: 849.3999, b: 80, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1 &832575517
 GameObject:
   m_ObjectHideFlags: 0
@@ -7184,7 +7144,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 1601309345}
+  m_Material: {fileID: 578149571}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
@@ -7353,8 +7313,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 0.00024414062, y: -283.57782}
-  m_SizeDelta: {x: 1080, y: 795.86414}
+  m_AnchoredPosition: {x: 9.256, y: -283.57782}
+  m_SizeDelta: {x: 788, y: 788}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &875495120
 MonoBehaviour:
@@ -7376,8 +7336,8 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 87ff1ad01a5c8a24286a1dc24db49657, type: 3}
-  m_Type: 0
+  m_Sprite: {fileID: 21300000, guid: cfa2ca4e77c004fde897e71890c12e1a, type: 3}
+  m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -8215,6 +8175,46 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1035653840}
   m_PrefabAsset: {fileID: 0}
+--- !u!21 &1059726197
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0.024052067, g: 0.022535274, b: 0.9789449, a: 0.9755116}
+    - _WidthHeightRadius: {r: 1192.5742, g: 319.42212, b: 80, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1001 &1067012250
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8669,46 +8669,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1333913872}
   m_PrefabAsset: {fileID: 0}
---- !u!21 &1342515366
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0.024052067, g: 0.022535274, b: 0.9789449, a: 0.9755116}
-    - _WidthHeightRadius: {r: 1192.5742, g: 319.42212, b: 80, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1 &1375761812
 GameObject:
   m_ObjectHideFlags: 0
@@ -8909,6 +8869,46 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1378479453}
   m_PrefabAsset: {fileID: 0}
+--- !u!21 &1400830121
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0.024052067, g: 0.022535274, b: 0.9789449, a: 0.9755116}
+    - _WidthHeightRadius: {r: 1192.5742, g: 319.42212, b: 80, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1 &1460646841
 GameObject:
   m_ObjectHideFlags: 0
@@ -9227,8 +9227,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 20, y: 138}
-  m_SizeDelta: {x: 350, y: 100}
+  m_AnchoredPosition: {x: 12, y: 106}
+  m_SizeDelta: {x: 350, y: 120}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1535448053
 MonoBehaviour:
@@ -9516,46 +9516,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1545194025}
   m_PrefabAsset: {fileID: 0}
---- !u!21 &1601309345
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
-    - _WidthHeightRadius: {r: 149.651, g: 51.939, b: 40, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1001 &1608619355
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10511,6 +10471,46 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1747515292}
   m_PrefabAsset: {fileID: 0}
+--- !u!21 &1772852000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 0.99999994, a: 1}
+    - _WidthHeightRadius: {r: 1275.0493, g: 849.3999, b: 80, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1 &1800503796
 GameObject:
   m_ObjectHideFlags: 0
@@ -10663,6 +10663,11 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 792557072500720335, guid: 2ef4c95d678195e479f8489a2227c5c5,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 894374716221063315, guid: 2ef4c95d678195e479f8489a2227c5c5,
         type: 3}
       propertyPath: m_Pivot.x
@@ -10763,6 +10768,12 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 943105701656828490, guid: 2ef4c95d678195e479f8489a2227c5c5,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 9320dce57bba0e346afa7da9d1a62ae6,
+        type: 3}
     - target: {fileID: 1715407823972043507, guid: 2ef4c95d678195e479f8489a2227c5c5,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -10771,22 +10782,22 @@ PrefabInstance:
     - target: {fileID: 1715407823972043507, guid: 2ef4c95d678195e479f8489a2227c5c5,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 203.317
+      value: 186.456
       objectReference: {fileID: 0}
     - target: {fileID: 1715407823972043507, guid: 2ef4c95d678195e479f8489a2227c5c5,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 41.199
+      value: 62.275
       objectReference: {fileID: 0}
     - target: {fileID: 1715407823972043507, guid: 2ef4c95d678195e479f8489a2227c5c5,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 25
+      value: 16.57
       objectReference: {fileID: 0}
     - target: {fileID: 1715407823972043507, guid: 2ef4c95d678195e479f8489a2227c5c5,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 8.482
+      value: 6.375
       objectReference: {fileID: 0}
     - target: {fileID: 2582669928173800608, guid: 2ef4c95d678195e479f8489a2227c5c5,
         type: 3}
@@ -10927,7 +10938,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Material
       value: 
-      objectReference: {fileID: 794713411}
+      objectReference: {fileID: 385330570}
     - target: {fileID: 8050266750327260882, guid: 2ef4c95d678195e479f8489a2227c5c5,
         type: 3}
       propertyPath: m_Type
@@ -10964,11 +10975,26 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Material
       value: 
-      objectReference: {fileID: 510692240}
+      objectReference: {fileID: 1400830121}
     - target: {fileID: 9180759222254172223, guid: 2ef4c95d678195e479f8489a2227c5c5,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9215215364731363124, guid: 2ef4c95d678195e479f8489a2227c5c5,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 274.555
+      objectReference: {fileID: 0}
+    - target: {fileID: 9215215364731363124, guid: 2ef4c95d678195e479f8489a2227c5c5,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: -10.061
+      objectReference: {fileID: 0}
+    - target: {fileID: 9215215364731363124, guid: 2ef4c95d678195e479f8489a2227c5c5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 10.885
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:


### PR DESCRIPTION
# 🧑‍💻 PR

## 🔗 관련 이슈
- 수행한 작업과 관련 작업 번호를 작성해주세요 
- Related to: #89


## 💻 버그 해결방법

### 💡 해결방법
![젠가 사이드 쪽을 클릭할 때 조금 이상함](https://github.com/user-attachments/assets/a7c56825-d3bf-45ad-9491-8b2cd9906ca2)
1. 확대 RT와 UI에 RawImage의 비율이 맞지 않아 사이드 블록에 터치가 잘 안되는 현상이 있었음
따라서 비율을 맞추어서 해결함

2. RT가 나타나지 않는 현상은  depth stencil Format 설정을 D16_UNORM로 변경하여 수정 (해당 문제는 갤럭시 노트9 같은 특정 기종에만 발생하는 것으로 판단하여 QA에 테스트가 필요함)

### ✔️ 버그 체크리스트
- [ ] 추가로 수정이 필요함
- [x] 수정 완료
- [ ] QA 테스트 통과

## ✅ PR 체크리스트
- [x] 빌드 오류 없음
- [x] 기능 정상 작동 확인
- [x] 커밋 메시지 규칙 준수
- [x] Scene 충돌 없음

