### PR TITLE
[Fix] 리듬게임 QA 버그 수정

### DIFF
--- a/Assets/KST/Scenes/Rhythm.unity
+++ b/Assets/KST/Scenes/Rhythm.unity
@@ -360,46 +360,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 28618288}
   m_PrefabAsset: {fileID: 0}
---- !u!21 &39119170
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
-    - _WidthHeightRadius: {r: 149.651, g: 51.939, b: 40, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1001 &70330344
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1400,7 +1360,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 39119170}
+  m_Material: {fileID: 959794809}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
@@ -2675,9 +2635,6 @@ MonoBehaviour:
   gameTimer: {fileID: 1804055936}
   IsGameStart: 0
   IsGameOver: 0
-  missScore: -5
-  overHeatPoint: 5
-  frozenPoint: 5
   overHeatMaxValue: 100
   IsOverHeat: 0
   overHeatingTime: 3
@@ -2685,6 +2642,7 @@ MonoBehaviour:
   - {fileID: 1846032767}
   - {fileID: 1398929283}
   - {fileID: 631666418}
+  - {fileID: 312057151}
   noteSpawnDist: 12
   playerPrefabName: Prefabs/Rhythm/RhythmUnimo
   backupPrefabName: Prefabs/Rhythm/RhythmPlayer
@@ -3165,6 +3123,46 @@ Transform:
   - {fileID: 1544092433}
   m_Father: {fileID: 1708770859}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!21 &959794809
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
+    - _WidthHeightRadius: {r: 149.651, g: 51.939, b: 40, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1001 &1041087433
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/KST/Scripts/RhythmGame/Manager/GameManager.cs
+++ b/Assets/KST/Scripts/RhythmGame/Manager/GameManager.cs
@@ -33,9 +33,9 @@ namespace RhythmGame
 
         //게임 규칙
         // [SerializeField] int hitScore = 100; //적중 시 점수
-        [SerializeField] int missScore = -5; // 미스 시 감점 점수
-        [SerializeField] int overHeatPoint = 5; // 미스 시 과열 증가
-        [SerializeField] int frozenPoint = 5; // 적중 시 과열 감소
+        int missScore = -1; // 미스 시 감점 점수
+        // [SerializeField] int overHeatPoint = 5; // 미스 시 과열 증가
+        // [SerializeField] int frozenPoint = 5; // 적중 시 과열 감소
         [SerializeField] int overHeatMaxValue = 100; // 임계치
 
         //과열 관리
@@ -201,6 +201,12 @@ namespace RhythmGame
             IsGameStart = false;
             IsGameOver = true;
 
+            if (PhotonNetwork.IsMasterClient)
+            {
+                var rankings = CalculateRanks();
+                BroadcastRankSnapshot(rankings);
+                SendResultToMainGame(rankings);
+            }
 
 
             //게임 종료 이벤트 호출
@@ -241,17 +247,17 @@ namespace RhythmGame
             switch (type)
             {
                 case NoteType.Fake:
-                    score = 4;
+                    score = -1;
                     // OverHeatCheck();
                     break;
 
                 case NoteType.Touch:
-                    score = 1;
+                    score = 17;
                     // FrozenHeat();
                     break;
 
                 case NoteType.Continue:
-                    score = 2;
+                    score = 31;
                     // FrozenHeat();
                     break;
             }
@@ -259,20 +265,20 @@ namespace RhythmGame
             return score;
         }
 
-        public void FrozenHeat()
-        {
-            if (!PhotonNetwork.IsMasterClient) return;
+        // public void FrozenHeat()
+        // {
+        //     if (!PhotonNetwork.IsMasterClient) return;
 
-            // 과열 변수 값 감소
-            overHeatValue = Mathf.Max(0, overHeatValue - frozenPoint);
+        //     // 과열 변수 값 감소
+        //     overHeatValue = Mathf.Max(0, overHeatValue - frozenPoint);
 
-            //과열 값 반영
-            ScoreManager.Instance.photonView.RPC(
-                nameof(ScoreManager.SetOverheat), RpcTarget.All, overHeatValue
-                );
+        //     //과열 값 반영
+        //     ScoreManager.Instance.photonView.RPC(
+        //         nameof(ScoreManager.SetOverheat), RpcTarget.All, overHeatValue
+        //         );
 
 
-        }
+        // }
 
         /// <summary>
         /// 과열 증가 로직
@@ -304,46 +310,20 @@ namespace RhythmGame
         /// <summary>
         /// 미스 시 개인점수 차감
         /// </summary>
-        public void MissBlock(Player actor)
+        public void MissBlock(Player actor, NoteType type)
         {
-            //개인 점수 차감
-            ScoreManager.Instance.photonView.
-            RPC(nameof(ScoreManager.MinusScore), RpcTarget.All, actor.ActorNumber, missScore);
+            if (type == NoteType.Fake)
+            {
+                ScoreManager.Instance.photonView.
+                                RPC(nameof(ScoreManager.AddScore), RpcTarget.All, actor.ActorNumber, 9);
+            }
+            else
+            {
+                //개인 점수 차감
+                ScoreManager.Instance.photonView.
+                RPC(nameof(ScoreManager.MinusScore), RpcTarget.All, actor.ActorNumber, missScore);
+            }
         }
-        [PunRPC]
-        public void DuringOverHeat()
-        {
-            Debug.Log("과열 발생");
-            IsOverHeat = true;
-        }
-        [PunRPC]
-        public void AfterOverHeat()
-        {
-            Debug.Log("과열 종료");
-            IsOverHeat = false;
-        }
-
-        // /// <summary>
-        // /// 과열 시 코루틴 실행. n초 뒤 과열 초기화 
-        // /// </summary>
-        // IEnumerator IE_OverHeating()
-        // {
-        //     //과열 시
-        //     photonView.RPC(nameof(DuringOverHeat), RpcTarget.All);
-        //     PlayerStunAnim(overHeatingTime);
-
-        //     yield return new WaitForSeconds(overHeatingTime);
-        //     //과열 시간 종료 후 로직
-
-        //     photonView.RPC(nameof(AfterOverHeat), RpcTarget.All);
-
-        //     overHeatValue = 0; //과열점수 리셋
-        //     Debug.Log($"과열 점수 초기화 {overHeatValue}");
-
-        //     ScoreManager.Instance.photonView.RPC(
-        //         nameof(ScoreManager.SetOverheat), RpcTarget.All, overHeatValue
-        //         );
-        // }
 
         public int LaneCapacity => playerPoints?.Length ?? 0;
 
@@ -400,33 +380,6 @@ namespace RhythmGame
             //위치, 회전
             return new Pose(pos, rot);
         }
-
-        // //플레이어 스턴
-        // public void PlayerStunAnim(float time)
-        // {
-        //     if (!PhotonNetwork.IsMasterClient) return;
-
-        //     foreach (var player in PhotonNetwork.PlayerList)
-        //     {
-        //         photonView.RPC(nameof(RPC_Stun), RpcTarget.All, player.ActorNumber, time);
-        //     }
-        // }
-
-        // [PunRPC]
-        // void RPC_Stun(int actorNum, float time)
-        // {
-        //     if (!PlayerController.AvatarByActor.TryGetValue(actorNum, out var avatar)) return;
-
-        //     if (avatar.TryGetComponent<PlayerAnimController>(out var anim))
-        //     {
-        //         Debug.Log("anim 있음");
-        //         anim.PlayeStunAnim(time);
-        //     }
-        //     else
-        //     {
-        //         Debug.LogWarning($"actorNum {actorNum}의 아바타에서 PlayerAnimController를 찾지 못함");
-        //     }
-        // }
 
         private void InitializePlayers()
         {
@@ -536,10 +489,9 @@ namespace RhythmGame
             if (players.TryGetValue(uid, out var rp)) rp.score = total;
 
             // 랭킹 계산/브로드캐스트
-            CalculateAndBroadcastRanks();
+            BroadcastRanks();
         }
-
-        private void CalculateAndBroadcastRanks()
+        private Dictionary<string, int> CalculateRanks()
         {
             // players 기준으로 빠진 UID는 0점으로 취급
             foreach (var uid in players.Keys)
@@ -555,9 +507,18 @@ namespace RhythmGame
             for (int i = 0; i < ordered.Count; i++)
                 ranks[ordered[i].Key] = i + 1;
 
+            return ranks;
+        }
+
+        private void BroadcastRanks()
+        {
+            if (!PhotonNetwork.IsMasterClient) return;
+
+            var ranks = CalculateRanks();
+
             BroadcastRankSnapshot(ranks);
-            OnRankingsUpdated?.Invoke(ranks);
-            _lastRankSnapshot = new Dictionary<string, int>(ranks);
+            // OnRankingsUpdated?.Invoke(ranks);
+            // _lastRankSnapshot = new Dictionary<string, int>(ranks);
         }
 
         public void BroadcastRankSnapshot(Dictionary<string, int> uidToRank)
@@ -568,7 +529,8 @@ namespace RhythmGame
             var vals = uidToRank.Values.ToArray();
 
             // 1) RPC 전파
-            photonView.RPC(nameof(RPC_SyncRanks), RpcTarget.All, uids, vals);
+            photonView.RPC(nameof(RPC_SyncRanks), RpcTarget.Others, uids, vals);
+            RPC_SyncRanks(uids, vals);
 
             // 2) 룸 프로퍼티 저장(레이트 조인 대비)
             var table = new Hashtable
@@ -615,6 +577,24 @@ namespace RhythmGame
             ranks = null;
             return false;
         }
+
+        /// <summary>
+        /// 메인 게임에 최종 승패 정보를 반영
+        /// (PlayerManager의 Player.WinThisMiniGame 플래그를 세팅)
+        /// </summary>
+        private void SendResultToMainGame(Dictionary<string, int> rankings)
+        {
+            MainGameManager.Instance.ReportMiniGameResult(rankings);
+            // foreach (var pair in rankings)
+            // {
+            //     var player = PlayerManager.Instance.GetPlayer(pair.Key);
+            //     if (player != null)
+            //     {
+            //         // player.WinThisMiniGame = (pair.Value == 1); // 1등이면 승리
+            //     }
+            // }
+        }
+
 
     }
 }

--- a/Assets/KST/Scripts/RhythmGame/Manager/ScoreManager.cs
+++ b/Assets/KST/Scripts/RhythmGame/Manager/ScoreManager.cs
@@ -149,32 +149,40 @@ namespace RhythmGame
             // LaneManager.Instance.LaneByNoteId.Remove(noteId);
             NoteSpawner.Instance.DestroyNote(noteId, isCanInteract);
 
-            // 득점 및 과열 처리
-            if (isCanInteract)
+            // 득점 처리
+
+            // 상호작용 불가능한 상태일 경우
+            if (!isCanInteract)
+            {
+                GameManager.Instance.MissBlock(info.Sender, type);
+                return;
+            }
+            //상호작용 가능할 때
+            if (type == NoteType.Fake)
+            {
+                GameManager.Instance.GoodHitScore(type, info.Sender);
+            }
+            //속임수 노트가 아닐 경우
+            else
             {
                 GameManager.Instance.GoodHitScore(type, info.Sender);
                 if (SoundManager.Instance != null)
                     SoundManager.Instance.PlaySFX
                     (type == NoteType.Continue ? "Continue" : "Touch");
-
-                return;
-                
             }
-            GameManager.Instance.MissBlock(info.Sender);
-            // SoundManager.Instance.PlaySFX_GAME(SfX_Game.SFX_Rhythm_Miss);
         }
 
-        public void RequestMiss()
+        public void RequestMiss(NoteType noteType)
         {
-            photonView.RPC(nameof(RPC_RequestMiss), RpcTarget.MasterClient);
+            photonView.RPC(nameof(RPC_RequestMiss), RpcTarget.MasterClient, noteType);
         }
 
         [PunRPC]
-        void RPC_RequestMiss(PhotonMessageInfo info)
+        void RPC_RequestMiss(NoteType type, PhotonMessageInfo info)
         {
             if (!PhotonNetwork.IsMasterClient) return;
             // GameManager.Instance.OverHeatCheck();
-            GameManager.Instance.MissBlock(info.Sender);
+            GameManager.Instance.MissBlock(info.Sender, type);
         }
 
         /// <summary>
@@ -190,8 +198,14 @@ namespace RhythmGame
             if (!LaneManager.Instance.GetLane(actorNum, out int actorLane)) return;
             //해당 액터의 레인과 노트 레인 일치 확인
             if (noteLane != actorLane) return;
+            if (!NoteSpawner.Instance.TryGetNote(noteId, out var note)) return;
+            var type = note.Type;
 
-            MissToAll(actorNum);
+            var player = PhotonNetwork.CurrentRoom?.GetPlayer(actorNum);
+            if(player!=null)
+                GameManager.Instance.MissBlock(player, type);
+
+            MissToAll(actorNum,type);
 
             //노트 파괴()
             NoteSpawner.Instance.DestroyNote(noteId, false);
@@ -206,17 +220,18 @@ namespace RhythmGame
         /// 모두에게 해당 노트가 miss 됐다는 것을 전파
         /// </summary>
         [PunRPC]
-        void RPC_MissToAll(int actorNum)
+        void RPC_MissToAll(int actorNum, NoteType type)
         {
             if (PhotonNetwork.LocalPlayer.ActorNumber == actorNum)
             {
-                VerdictMiss();
+                VerdictMiss(type);
+                // GameManager.Instance.MissBlock(PhotonNetwork.LocalPlayer, type);
             }
         }
 
-        void MissToAll(int actorNum)
+        void MissToAll(int actorNum, NoteType type)
         {
-            photonView.RPC(nameof(RPC_MissToAll), RpcTarget.All, actorNum);
+            photonView.RPC(nameof(RPC_MissToAll), RpcTarget.All, actorNum, type);
         }
 
         /// <summary>
@@ -283,8 +298,11 @@ namespace RhythmGame
         /// 미스 처리
         /// </summary>
         /// <returns></returns>
-        public Verdict VerdictMiss()
+        public Verdict VerdictMiss(NoteType type)
         {
+            if (type == NoteType.Fake)
+                return ApplyVerdict(Verdict.Perfect);
+
             return ApplyVerdict(Verdict.Miss);
         }
 

--- a/Assets/KST/Scripts/RhythmGame/Note/VerdictNote.cs
+++ b/Assets/KST/Scripts/RhythmGame/Note/VerdictNote.cs
@@ -43,12 +43,12 @@ namespace RhythmGame
 
             note.Status = NoteStatus.None;
 
-            //속임수 블럭의 경우 미스처리 금지.
-            if (note.Type == NoteType.Fake)
-            {
-                ScoreManager.Instance.RequestMissFake(note.NoteId);
-                return;
-            }
+            // //속임수 블럭의 경우 미스처리 금지.
+            // if (note.Type == NoteType.Fake)
+            // {
+            //     ScoreManager.Instance.RequestMissFake(note.NoteId);
+            //     return;
+            // }
 
             if (!TryGetLane(out int myLane)) return;
             //내 레인이 아닐경우 금지

--- a/Assets/KST/Scripts/RhythmGame/Player/RhythmPlayerInput.cs
+++ b/Assets/KST/Scripts/RhythmGame/Player/RhythmPlayerInput.cs
@@ -40,7 +40,7 @@ namespace RhythmGame
             }
             else
             {
-                ScoreManager.Instance.RequestMiss();
+                ScoreManager.Instance.RequestMiss(NoteType.Continue);
                 _isDone = true;
                 InitHold();
             }
@@ -120,7 +120,7 @@ namespace RhythmGame
                     ScoreManager.Instance.RequestHit(_holdTarget.NoteId, true, NoteType.Continue);
                 }
                 else
-                    ScoreManager.Instance.RequestMiss();
+                    ScoreManager.Instance.RequestMiss(NoteType.Continue);
 
                 InitHold();
                 _noteToTap.Clear();
@@ -131,6 +131,7 @@ namespace RhythmGame
             if (_noteToTap.Count > 0)
             {
                 bool anyHit = false;
+                NoteType? missType = null;
                 foreach (var t in _noteToTap)
                 {
 
@@ -140,6 +141,9 @@ namespace RhythmGame
 
                     if (t.Type == NoteType.Continue) continue;
 
+                    if (missType == null)
+                        missType = t.Type;
+
                     bool isCan = t.Status == NoteStatus.CanInteract && IsInVerdictBar(t);
 
                     if (isCan)
@@ -148,25 +152,19 @@ namespace RhythmGame
                         NoteSpawner.Instance.ClientLocalHit(t.NoteId);
                         ScoreManager.Instance.RequestHit(t.NoteId, true, t.Type);
                         anyHit = true;
-
                     }
-                    // else
-                    // {
-                    //     ScoreManager.Instance.RequestMiss();
-                    //     ScoreManager.Instance.VerdictMiss();
-                    // }
                 }
-                if (!anyHit)
+                if (!anyHit && missType.HasValue)
                 {
-                    ScoreManager.Instance.RequestMiss();
-                    ScoreManager.Instance.VerdictMiss();
+                    ScoreManager.Instance.RequestMiss(missType.Value);
+                    ScoreManager.Instance.VerdictMiss(missType.Value);
                 }
                 _noteToTap.Clear();
             }
             else
             {
-                ScoreManager.Instance.RequestMiss();
-                ScoreManager.Instance.VerdictMiss();
+                ScoreManager.Instance.RequestMiss(NoteType.Touch);
+                ScoreManager.Instance.VerdictMiss(NoteType.Touch);
             }
 
         }


### PR DESCRIPTION
# 🧑‍💻 PR


## 🔥 작업 내용 요약
1. 속임수 블노트판정 변경
2. 4인 모드 시 3인만 등장하는 이슈 해결
3. 블럭 흘릴 때 스코어 감소하지 않는 문제 해결

<br>

## 💻 작업 구현 방법 (공통)
### 📝 구현 설명
1. 속임수 노트 판정의 경우 놓칠 경우 점수를 획득하도록, 탭 판정 시 noteType에 따른 분기 로직 처리를 통해 속임수 노트일 경우 점수를 감점시키도록 변경

2. GameManager에서 4번째 플레이어의 Transform을 참조하지 않아서 플레이어가 등장하지 않았던 문제여서 참조를 추가로 걸어놨음.

<br>

## 💻 버그 해결방법 (Fix 전용)

### 🔧 수정된 버그
<!--
예) 아이템 호버링, 사운드 누락
-->

### 💡 해결방법
- 어떠한 방식을 해결을 했는지 설명

## ✅ PR 체크리스트
- [ ] 빌드 오류 없음
- [ ] 기능 정상 작동 확인
- [ ] 커밋 메시지 규칙 준수
- [ ] Scene 충돌 없음

## 💬 기타 사항
- 리뷰어에게 공유하고 싶은 내용