### PR TITLE
[Refactor] 로딩창 로직 변경 (구글 시트와 연동)

### DIFF
--- a/Assets/LDH/LDH_Scripts/UI/01_Popup/UI_Loading.cs
+++ b/Assets/LDH/LDH_Scripts/UI/01_Popup/UI_Loading.cs
@@ -12,7 +12,6 @@ namespace LDH_UI
     {
         [Header("Loading UI")]
         [SerializeField] private TMP_Text title;               // 큰 제목
-        [SerializeField] private TMP_Text bigDescription;      // 메인 설명(큰 글씨)
         [SerializeField] private TMP_Text smallDescription;    // 서브 설명(작은 글씨)
 
         [Header("Common Visuals (Prefab handles colors/background)")]
@@ -60,15 +59,28 @@ namespace LDH_UI
         {
             if (!theme) return;
 
-            SetTitle(theme.gameTitle);
-            SetBigDescription(theme.bigDescription);
-            SetSmallDescription(theme.smallDescription);
-
             SetTitlePanelColor(theme.titlePanelColor);
             SetBackgroundPanelColor(theme.backgroundPanelColor);
             SetDescriptionPanelColor(theme.descriptionPanelColor);
 
             SpawnRandomUnimo(theme.unimoPrefabs);
+
+            if (theme.useGoogleSheetsText && GoogleSheetsLoadingManager.Instance != null)
+            {
+                // 구글시트에서 해당 카테고리 텍스트 가져오기
+                string category = theme.GetActiveCategory();
+                var textData = GoogleSheetsLoadingManager.Instance.GetRandomLoadingData(category);
+                SetTitle(textData.gameTitle);
+                SetSmallDescription(textData.smallDescription);
+                Debug.Log($"구글시트 텍스트 적용: {theme.themeType} → '{category}' 카테고리");
+            }
+            else
+            {
+                // 테마의 고정 텍스트 사용
+                SetTitle(theme.gameTitle);
+                SetSmallDescription(theme.smallDescription);
+                Debug.Log($"테마 고정 텍스트 적용: {theme.themeType}");
+            }
         }
 
         /// <summary>
@@ -84,10 +96,7 @@ namespace LDH_UI
         {
             if (title) title.text = text ?? string.Empty;
         }
-        public void SetBigDescription(string text)
-        {
-            if (bigDescription) bigDescription.text = text ?? string.Empty;
-        }
+       
         public void SetSmallDescription(string text)
         {
             if (smallDescription) smallDescription.text = text ?? string.Empty;

--- a/Assets/LTH/LTH_Prefabs/UI/Jenga_Theme.asset
+++ b/Assets/LTH/LTH_Prefabs/UI/Jenga_Theme.asset
@@ -12,8 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 16e882dba42855d41b248d3300c2d923, type: 3}
   m_Name: Jenga_Theme
   m_EditorClassIdentifier: 
+  themeType: 3
+  themeName: Jenga
   gameTitle: "\uC820\uAC00\uC2A4\uD0C0!"
-  bigDescription: 
   smallDescription: "\uC820\uAC00 \uBE14\uB7ED\uC744 \uD0C0\uC774\uBC0D\uC5D0 \uB9DE\uCDB0\uC11C
     \uBE60\uB974\uAC8C \uC810\uC218\uB97C \uC313\uC544\uBCF4\uC138\uC694 !"
   titlePanelColor: {r: 0, g: 0, b: 0, a: 1}
@@ -22,3 +23,5 @@ MonoBehaviour:
   unimoPrefabs:
   - {fileID: 3380019038747022192, guid: 658f3813a0c86d341878bb3628d1b24f, type: 3}
   - {fileID: 3380019038747022192, guid: f61a8b3cfcc1fb7479287411ec8fb801, type: 3}
+  useGoogleSheetsText: 1
+  sheetCategory: Jenga

--- a/Assets/LTH/LTH_Scripts/Loadings/GoogleSheetsLoadingManager.cs
+++ b/Assets/LTH/LTH_Scripts/Loadings/GoogleSheetsLoadingManager.cs
@@ -1,0 +1,172 @@
+using System.Collections;
+using System.Collections.Generic;
+using DesignPattern;
+using LDH_UI;
+using UnityEngine;
+using UnityEngine.Networking;
+
+public class GoogleSheetsLoadingManager : CombinedSingleton<GoogleSheetsLoadingManager>
+{
+    [Header("구글 시트 설정")]
+    [SerializeField] private string sheetURL = ""; // CSV 공개 링크
+    [SerializeField] private float refreshInterval = 300f; // 5분마다 갱신
+    [SerializeField] private bool loadOnStart = true; // 게임 시작시 자동 로딩
+
+    private Dictionary<string, List<LoadingTextData>> categorizedData = new Dictionary<string, List<LoadingTextData>>();
+    private List<LoadingTextData> allLoadingData = new List<LoadingTextData>();
+    private bool isDataReady = false;
+    private bool isLoading = false;
+
+    protected override void OnAwake()
+    {
+        if (loadOnStart)
+        {
+            StartCoroutine(LoadDataFromSheet());
+        }
+    }
+
+    void Start()
+    {
+        // 주기적으로 데이터 갱신
+        if (refreshInterval > 0)
+        {
+            InvokeRepeating(nameof(RefreshData), refreshInterval, refreshInterval);
+        }
+    }
+
+    private void RefreshData()
+    {
+        StartCoroutine(LoadDataFromSheet());
+    }
+
+    private IEnumerator LoadDataFromSheet()
+    {
+        if (isLoading) yield break; // 중복 로딩 방지
+
+        isLoading = true;
+        Debug.Log("구글시트에서 로딩 데이터 가져오는 중...");
+
+        using (UnityWebRequest request = UnityWebRequest.Get(sheetURL))
+        {
+            yield return request.SendWebRequest();
+
+            if (request.result == UnityWebRequest.Result.Success)
+            {
+                ParseCSVData(request.downloadHandler.text);
+                isDataReady = true;
+                Debug.Log($"로딩 데이터 갱신 완료: {allLoadingData.Count}개");
+            }
+            else
+            {
+                Debug.LogError($"시트 로딩 실패: {request.error}");
+                // 실패시 기본 데이터 사용
+                if (allLoadingData.Count == 0)
+                {
+                    LoadDefaultData();
+                }
+            }
+        }
+
+        isLoading = false;
+    }
+
+    private void ParseCSVData(string csvData)
+    {
+        allLoadingData.Clear();
+        categorizedData.Clear();
+        string[] lines = csvData.Split('\n');
+
+        // 첫 번째 줄은 헤더이므로 스킵 (제목, 내용, 게임) 또는 (gameTitle, smallDescription, category)
+        for (int i = 1; i < lines.Length; i++)
+        {
+            if (string.IsNullOrEmpty(lines[i].Trim())) continue;
+
+            string[] values = lines[i].Split(',');
+            if (values.Length >= 2)
+            {
+                string category = values.Length >= 3 ? values[2].Trim().Trim('"') : "default";
+
+                var data = new LoadingTextData(
+                    values[0].Trim().Trim('"'), // 제목 (gameTitle)
+                    values[1].Trim().Trim('"'), // 내용 (smallDescription)
+                    category                    // 지정 (category)
+                );
+
+                allLoadingData.Add(data);
+
+                // 카테고리별로 분류
+                if (!categorizedData.ContainsKey(category))
+                {
+                    categorizedData[category] = new List<LoadingTextData>();
+                }
+                categorizedData[category].Add(data);
+            }
+        }
+
+        Debug.Log($"로딩 데이터 파싱 완료: 총 {allLoadingData.Count}개, 카테고리 {categorizedData.Count}개");
+    }
+
+    private void LoadDefaultData()
+    {
+        var defaultData = new List<LoadingTextData>
+        {
+            new LoadingTextData("로딩 중...", "잠시만 기다려주세요", "Default"),
+            new LoadingTextData("곧 시작해요", "준비 완료까지 조금만 더!", "Default"),
+            new LoadingTextData("젠가스타", "젠가 블럭을 타이밍에 맞워서 빠르게 점수를 쌓아보세요!", "Jenga"),
+            new LoadingTextData("날아라 유니모", "타이밍에 맞춰 유니모를 날려주세요!", "Shooting"),
+            new LoadingTextData("세어라 별똥별", "떨어지는 운석을 조심하면서, 별똥별을 세어보세요", "Meteor"),
+            new LoadingTextData("스타 이스케이프", "노트를 최대한 정확하게 맞춰서 1등을 노려보도록 하세요!", "Rhythm"),
+        };
+
+        allLoadingData = defaultData;
+        categorizedData.Clear();
+
+        foreach (var data in defaultData)
+        {
+            if (!categorizedData.ContainsKey(data.category))
+            {
+                categorizedData[data.category] = new List<LoadingTextData>();
+            }
+            categorizedData[data.category].Add(data);
+        }
+
+        isDataReady = true;
+    }
+
+    public LoadingTextData GetRandomLoadingData(string category = "Default")
+    {
+        if (!isDataReady)
+        {
+            Debug.LogWarning($"데이터가 준비되지 않음. 기본값 반환: {category}");
+            return new LoadingTextData("로딩 중...", "잠시만 기다려주세요", category);
+        }
+
+        // 해당 카테고리 데이터가 있으면 그것에서 선택
+        if (categorizedData.ContainsKey(category) && categorizedData[category].Count > 0)
+        {
+            var categoryList = categorizedData[category];
+            int randomIndex = Random.Range(0, categoryList.Count);
+            Debug.Log($"카테고리 '{category}' 데이터 {categoryList.Count}개 중 {randomIndex}번째 선택");
+            return categoryList[randomIndex];
+        }
+
+        // 카테고리가 없으면 경고 후 전체에서 선택
+        Debug.LogWarning($"카테고리 '{category}' 없음! 사용 가능한 카테고리: [{string.Join(", ", categorizedData.Keys)}]");
+
+        if (allLoadingData.Count > 0)
+        {
+            int randomIndex = Random.Range(0, allLoadingData.Count);
+            return allLoadingData[randomIndex];
+        }
+
+        // 완전히 데이터가 없으면 기본값
+        return new LoadingTextData("로딩 중...", "잠시만 기다려주세요", category);
+    }
+
+    public List<string> GetAvailableCategories()
+    {
+        return new List<string>(categorizedData.Keys);
+    }
+
+    public bool IsDataReady => isDataReady;
+}

--- a/Assets/LTH/LTH_Scripts/Loadings/GoogleSheetsLoadingManager.cs.meta
+++ b/Assets/LTH/LTH_Scripts/Loadings/GoogleSheetsLoadingManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3b3098b4caebd33468630872821e9772
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LTH/LTH_Scripts/Loadings/LoadingTextData.cs
+++ b/Assets/LTH/LTH_Scripts/Loadings/LoadingTextData.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System;
+
+// 게임 테마 Enum 정의
+[Serializable]
+public enum GameThemeType
+{
+    Default,        // 공용
+    Shooting,       // 슈팅 미니게임
+    Meteor,         // 별똥별 미니게임
+    Jenga,          // 젠가 미니게임
+    Rhythm,         // 리듬 미니게임
+}
+
+[Serializable]
+/// <summary>
+/// 구글 시트 연동용 로딩 텍스트 데이터 클래스
+/// </summary>
+public class LoadingTextData
+{
+    public string gameTitle;
+    public string smallDescription;
+    public string category;
+
+    public LoadingTextData(string title, string smallDesc, string cat = "Default")
+    {
+        gameTitle = title;
+        smallDescription = smallDesc;
+        category = cat;
+    }
+}

--- a/Assets/LTH/LTH_Scripts/Loadings/LoadingTextData.cs.meta
+++ b/Assets/LTH/LTH_Scripts/Loadings/LoadingTextData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 534c5b0f44e0a3941aa68ae8d15afe16
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LTH/LTH_Scripts/Loadings/UI_LoadingTheme.cs
+++ b/Assets/LTH/LTH_Scripts/Loadings/UI_LoadingTheme.cs
@@ -3,10 +3,13 @@ using UnityEngine;
 [CreateAssetMenu(menuName = "UI/Loading Theme", fileName = "NewLoadingTheme")]
 public class UI_LoadingTheme : ScriptableObject
 {
-    [Header("텍스트")]
+    [Header("테마 식별")]
+    public GameThemeType themeType;              
+    public string themeName;                     // 표시용 이름
+
+    [Header("기본 텍스트 (구글시트 미사용시)")]
     public string gameTitle;                     // 큰 제목
-    [TextArea] public string bigDescription;     // 메인 설명 (큰 글씨)
-    [TextArea] public string smallDescription;   // 서브 설명 (작은 글씨)
+    [TextArea] public string smallDescription;   // 서브 설명
 
     [Header("배경 색")]
     public Color titlePanelColor = Color.black;         // 제목 색 (기본값: 검정색)
@@ -15,4 +18,28 @@ public class UI_LoadingTheme : ScriptableObject
 
     [Header("유니모 연출")]
     public GameObject[] unimoPrefabs;            // 랜덤 뽑기용 유니모 프리팹 리스트
+
+    [Header("구글시트 연동 설정")]
+    public bool useGoogleSheetsText = true;      // 구글시트 텍스트 사용 여부
+    public string sheetCategory;                 // 구글시트에서 가져올 카테고리
+
+
+    public string GetCategoryFromEnum()
+    {
+        return themeType switch
+        {
+            GameThemeType.Shooting => "Shooting",
+            GameThemeType.Meteor => "Meteor",
+            GameThemeType.Jenga => "Jenga",
+            GameThemeType.Rhythm => "Rhythm",
+            GameThemeType.Default => "Default",
+            _ => "Default"
+        }; 
+    }
+
+         // 실제 사용할 카테고리 반환 (수동 입력이 있으면 우선 사용)
+    public string GetActiveCategory()
+    {
+        return string.IsNullOrEmpty(sheetCategory) ? GetCategoryFromEnum() : sheetCategory;
+    }
 }

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaSceneController/JengaSceneController.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaSceneController/JengaSceneController.cs
@@ -56,7 +56,6 @@ public class JengaSceneController : BaseGameSceneController
         {
             // 기본 텍스트라도 설정
             _uiLoading.SetTitle("JENGA GAME");
-            _uiLoading.SetBigDescription("준비 중...");
             _uiLoading.SetAllPanelColors(Color.black, Color.gray, Color.white);
         }
 
@@ -154,7 +153,6 @@ public class JengaSceneController : BaseGameSceneController
             if (_uiLoading)
             {
                 _uiLoading.SetProgress(1.0f);
-                _uiLoading.SetBigDescription("게임이 시작됩니다!");
             }
 
             // 로딩창 닫기

--- a/Assets/Resources/Prefabs/@Manager.prefab
+++ b/Assets/Resources/Prefabs/@Manager.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: -2621797398405278423}
   - component: {fileID: -1353870247722273129}
   - component: {fileID: -7566601843377880580}
+  - component: {fileID: 7411262195276897298}
   m_Layer: 0
   m_Name: '@Manager'
   m_TagString: Untagged
@@ -132,6 +133,22 @@ MonoBehaviour:
   isPersistent: 1
   ParticlePoolRegister_Transform: {fileID: 5845888735509695037}
   particles: []
+--- !u!114 &7411262195276897298
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1005027553336937955}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3b3098b4caebd33468630872821e9772, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isPersistent: 1
+  sheetURL: https://docs.google.com/spreadsheets/d/1Zu13He97PYobSaHt1cAOWcnJRZZgHqzdqZghzdyuHlI/export?format=csv&gid=730171835
+  refreshInterval: 300
+  loadOnStart: 1
 --- !u!1 &1379040109739422052
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
# 🧑‍💻 PR

## 🔥 작업 내용 요약
1. [Refactor] 로딩창 로직 변경 (구글 시트와 연동)

## 💻 작업 구현 방법
### 📝 구현 설명
기존 : ScriptableObject에서 Text를 직접 설정
변경 : Google Sheet에서 Text를 작성하면 유니티에서 업데이트

### ❓구현 의도
기획팀이 직접 Google Sheet에서 Text를 설정할 수 있어 개발자가 Text를 계속 업데이트 하지 않아도 됨

## ✅ PR 체크리스트
- [ ] 빌드 오류 없음
- [ ] 기능 정상 작동 확인
- [ ] 커밋 메시지 규칙 준수
- [ ] Scene 충돌 없음

## 특이사항
BigDescription 관련 코드를 작성한 팀원 분들께서는 관련 코드 삭제 부탁드리겠습니다! @rnrgll @tiga1207 
MainGame_UIBinder, GameBootstrap, RhythmSceneController 발견한 클래스는 이렇게 3개입니다.