### PR TITLE
[Fix] GPGS 로그인 이후 로비 진입 안되는 문제, 보상창 버튼이 작동하지 않는 오류 수정

### DIFF
--- a/Assets/KYG/KYG_Scene/Login Scene.unity
+++ b/Assets/KYG/KYG_Scene/Login Scene.unity
@@ -2143,18 +2143,6 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1974923860}
-        m_TargetAssemblyTypeName: KYG.Auth.GPGSLoginManager, Assembly-CSharp
-        m_MethodName: LoginWithGPGS
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 9199652751304874121}
         m_TargetAssemblyTypeName: SfxPlayer, Assembly-CSharp
         m_MethodName: Play

--- a/Assets/KYG/KYG_Scripts/Auth/AuthBootstrapper.cs
+++ b/Assets/KYG/KYG_Scripts/Auth/AuthBootstrapper.cs
@@ -6,109 +6,111 @@ using UnityEngine;
 using Photon.Pun;
 using KYG.Auth;
 using LDH_Game;
+using LDH_Util;
 using Photon.Pun.Demo.Procedural;
 using UnityEngine.EventSystems;
 
 namespace KYG
 {
-    
-public class AuthBootstrapper : MonoBehaviour
-{
-    [Header("Firebase Realtime DB URL (닉네임/세션에서 사용)")]
-    [SerializeField] private string databaseUrl =
-        "https://<your-project-id>.firebaseio.com"; // ★ 콘솔 URL로 교체
-
-    [Header("자동 로그인 제어")]
-    [Tooltip("개발용: true면 앱 시작 시 무조건 로그인 UI 노출")]
-    [SerializeField] private bool forceShowLoginUI = false;
-
-    [Tooltip("최근 세션 킥이 있었으면 자동 로그인 시도 대신 UI로 폴백하는 쿨다운(초)")]
-    [SerializeField] private int kickCooldownSeconds = 10;
-
-    [Header("기본 닉네임(표시명이 비었을 때)")]
-    [SerializeField] private string defaultNick = "Player";
-
-    [Header("Verbose Logs")]
-    [SerializeField] private bool verbose = true;
-
-    private void Awake()
+    public class AuthBootstrapper : MonoBehaviour
     {
-        DontDestroyOnLoad(gameObject);
+        [Header("Firebase Realtime DB URL (닉네임/세션에서 사용)")] [SerializeField]
+        private string databaseUrl =
+            "https://<your-project-id>.firebaseio.com"; // ★ 콘솔 URL로 교체
 
-        // (선택) GPGS Activate는 GPGSLoginManager에서 이미 하고 있다면 생략 가능
-        try { GooglePlayGames.PlayGamesPlatform.Activate(); } catch { /* ignore */ }
+        [Header("자동 로그인 제어")] [Tooltip("개발용: true면 앱 시작 시 무조건 로그인 UI 노출")] [SerializeField]
+        private bool forceShowLoginUI = false;
 
-        // (중요) 전역 네트워크 보강 유틸들을 씬에 없으면 자동 생성
-        EnsureGlobalNetGlueObjects();
-    }
+        [Tooltip("최근 세션 킥이 있었으면 자동 로그인 시도 대신 UI로 폴백하는 쿨다운(초)")] [SerializeField]
+        private int kickCooldownSeconds = 10;
 
-    private async void Start()
-    {
-        
-        // 로그아웃 직후 1회: 어떤 자동 로그인도 금지하고 UI만 띄움
-        if (AuthAutoSuppressor.Consume())
+        [Header("기본 닉네임(표시명이 비었을 때)")] [SerializeField]
+        private string defaultNick = "Player";
+
+        [Header("Verbose Logs")] [SerializeField]
+        private bool verbose = true;
+
+        private void Awake()
         {
-            Debug.Log("[AuthBootstrapper] auto-login suppressed → 대기 상태");
-            return;
-        }
-        
-        if (!await FirebaseInitGate.EnsureReadyAsync())
-        {
-            Debug.LogError("Firebase not ready"); 
-            return;
-        }
-        
-        // 1) Firebase 준비
-        var dep = await FirebaseApp.CheckAndFixDependenciesAsync();
-        if (dep != DependencyStatus.Available)
-        {
-            Debug.LogError($"[AuthBootstrapper] Firebase deps: {dep}");
-            return;
-        }
+            DontDestroyOnLoad(gameObject);
 
-        // 2) Realtime DB URL 전달 (닉네임/세션 유틸들이 의존)
-        if (string.IsNullOrWhiteSpace(databaseUrl) || !databaseUrl.StartsWith("https://"))
-        {
-            Debug.LogError("[AuthBootstrapper] Realtime DB URL을 올바르게 설정하세요.");
-            return;
-        }
-        // 닉네임 레지스트리 사용 중이라면 여기에 ConfigureDatabase(...) 호출 (프로젝트에 따라)
-        // NicknameRegistry.ConfigureDatabase(databaseUrl);
-
-        // 3) 개발자 강제 UI 옵션
-        if (forceShowLoginUI)
-        {
-            return;
-        }
-
-        // 4) 최근 '세션 킥'이 있었으면 자동 로그인 대신 UI로 폴백 (핑퐁 방지)
-        if (kickCooldownSeconds > 0 && SessionEnforcer.WasKickedRecently(kickCooldownSeconds * 1000))
-        {
-            if (verbose) Debug.Log("[AuthBootstrapper] 최근 세션 킥 감지 → 자동 로그인 보류, UI 표시");
-            return;
-        }
-
-        var auth = FirebaseAuth.DefaultInstance;
-        var cur  = auth.CurrentUser;
-
-        // 5) 기존 Firebase 세션이 있으면 그것부터 재사용 (가장 빠르고 안전)
-        if (cur != null)
-        {
-            await ContinueWithExistingUserAsync(cur);
-            return;
-        }
-
-        // 6) Firebase 세션이 없으면 → 마지막 로그인 수단(guest/gpgs)으로 무팝업 자동 로그인 시도
-        if (AuthAccount.TryGet(out var provider, out var lastUid, out var lastNick))
-        {
-            if (verbose) Debug.Log($"[AuthBootstrapper] Try auto-login: last={provider}");
-
-            if (provider == "guest")
+            // (선택) GPGS Activate는 GPGSLoginManager에서 이미 하고 있다면 생략 가능
+            try { GooglePlayGames.PlayGamesPlatform.Activate(); }
+            catch
             {
-                // 게스트 자동 로그인: 닉네임이 있으면 재사용
-                await TryAutoGuestAsync(lastNick);
+                /* ignore */
+            }
+
+            // (중요) 전역 네트워크 보강 유틸들을 씬에 없으면 자동 생성
+            EnsureGlobalNetGlueObjects();
+        }
+
+        private async void Start()
+        {
+            // 로그아웃 직후 1회: 어떤 자동 로그인도 금지하고 UI만 띄움
+            if (AuthAutoSuppressor.Consume())
+            {
+                Debug.Log("[AuthBootstrapper] auto-login suppressed → 대기 상태");
                 return;
             }
+
+            if (!await FirebaseInitGate.EnsureReadyAsync())
+            {
+                Debug.LogError("Firebase not ready");
+                return;
+            }
+
+            // 1) Firebase 준비
+            var dep = await FirebaseApp.CheckAndFixDependenciesAsync();
+            if (dep != DependencyStatus.Available)
+            {
+                Debug.LogError($"[AuthBootstrapper] Firebase deps: {dep}");
+                return;
+            }
+
+            // 2) Realtime DB URL 전달 (닉네임/세션 유틸들이 의존)
+            if (string.IsNullOrWhiteSpace(databaseUrl) || !databaseUrl.StartsWith("https://"))
+            {
+                Debug.LogError("[AuthBootstrapper] Realtime DB URL을 올바르게 설정하세요.");
+                return;
+            }
+            // 닉네임 레지스트리 사용 중이라면 여기에 ConfigureDatabase(...) 호출 (프로젝트에 따라)
+            // NicknameRegistry.ConfigureDatabase(databaseUrl);
+
+            // 3) 개발자 강제 UI 옵션
+            if (forceShowLoginUI)
+            {
+                return;
+            }
+
+            // 4) 최근 '세션 킥'이 있었으면 자동 로그인 대신 UI로 폴백 (핑퐁 방지)
+            if (kickCooldownSeconds > 0 && SessionEnforcer.WasKickedRecently(kickCooldownSeconds * 1000))
+            {
+                if (verbose) Debug.Log("[AuthBootstrapper] 최근 세션 킥 감지 → 자동 로그인 보류, UI 표시");
+                return;
+            }
+
+            var auth = FirebaseAuth.DefaultInstance;
+            var cur = auth.CurrentUser;
+
+            // 5) 기존 Firebase 세션이 있으면 그것부터 재사용 (가장 빠르고 안전)
+            if (cur != null)
+            {
+                await ContinueWithExistingUserAsync(cur);
+                return;
+            }
+
+            // 6) Firebase 세션이 없으면 → 마지막 로그인 수단(guest/gpgs)으로 무팝업 자동 로그인 시도
+            if (AuthAccount.TryGet(out var provider, out var lastUid, out var lastNick))
+            {
+                if (verbose) Debug.Log($"[AuthBootstrapper] Try auto-login: last={provider}");
+
+                if (provider == "guest")
+                {
+                    // 게스트 자동 로그인: 닉네임이 있으면 재사용
+                    await TryAutoGuestAsync(lastNick);
+                    return;
+                }
 #if UNITY_ANDROID && !UNITY_EDITOR
             else if (provider == "gpgs")
             {
@@ -116,77 +118,78 @@ public class AuthBootstrapper : MonoBehaviour
                 return;
             }
 #endif
-        }
-
-        // 7) 완전 첫 실행 또는 정보 불충분 → UI
-    }
-
-    // ------------------ 내부 구현 ------------------
-
-    /// <summary>
-    /// Firebase 세션 유지 중: 세션 소유권(단일 세션) 확보 → Photon/Nickname 반영
-    /// </summary>
-    private async Task ContinueWithExistingUserAsync(FirebaseUser user)
-    {
-        string nick = string.IsNullOrEmpty(user.DisplayName) ? defaultNick : user.DisplayName;
-
-        // ★ 단일 세션 시작(동시 접속 차단): 내 기기가 /sessions/{uid}를 소유하도록
-        var enf = FindObjectOfType<SessionEnforcer>(true);
-        if (enf != null)
-        {
-            var ok = await enf.StartForUidAsync(user.UserId);
-            if (!ok)
-            {
-                Debug.LogWarning("[AuthBootstrapper] SessionEnforcer 실패 → UI로 폴백");
-                // ShowLoginUI();
-                return;
             }
+
+            // 7) 완전 첫 실행 또는 정보 불충분 → UI
         }
 
-        // 로컬 저장 갱신(다음 실행 자동 로그인용)
-        AuthAccount.Remember(user.IsAnonymous ? "guest" : "gpgs", user.UserId, nick);
+        // ------------------ 내부 구현 ------------------
 
-        // Photon 쪽에 UID/Nick 반영 후 게임 부트
-        ApplyPhotonAndStart(user.UserId, nick);
-    }
-
-    /// <summary>
-    /// 게스트 무팝업 자동 로그인(닉네임 재사용). 실패 시 UI로 폴백.
-    /// </summary>
-    private async Task TryAutoGuestAsync(string nickname)
-    {
-        try
+        /// <summary>
+        /// Firebase 세션 유지 중: 세션 소유권(단일 세션) 확보 → Photon/Nickname 반영
+        /// </summary>
+        private async Task ContinueWithExistingUserAsync(FirebaseUser user)
         {
-            var auth  = FirebaseAuth.DefaultInstance;
-            var res   = await auth.SignInAnonymouslyAsync();
-            var user  = res.User;
-            string nn = string.IsNullOrEmpty(nickname) ? defaultNick : nickname;
+            string nick = string.IsNullOrEmpty(user.DisplayName) ? defaultNick : user.DisplayName;
 
-            // (선택) DisplayName 업데이트로 Photon Nick 동기화 쉽게
-            await user.UpdateUserProfileAsync(new UserProfile { DisplayName = nn });
-
-            // ★ 단일 세션 시작
+            // ★ 단일 세션 시작(동시 접속 차단): 내 기기가 /sessions/{uid}를 소유하도록
             var enf = FindObjectOfType<SessionEnforcer>(true);
             if (enf != null)
             {
                 var ok = await enf.StartForUidAsync(user.UserId);
                 if (!ok)
                 {
-                    ShowLoginUI(); return;
+                    Debug.LogWarning("[AuthBootstrapper] SessionEnforcer 실패 → UI로 폴백");
+                    // ShowLoginUI();
+                    return;
                 }
             }
 
-            // 로컬 저장
-            AuthAccount.Remember("guest", user.UserId, nn);
+            // 로컬 저장 갱신(다음 실행 자동 로그인용)
+            AuthAccount.Remember(user.IsAnonymous ? "guest" : "gpgs", user.UserId, nick);
 
-            ApplyPhotonAndStart(user.UserId, nn);
+            // Photon 쪽에 UID/Nick 반영 후 게임 부트
+            ApplyPhotonAndStart(user.UserId, nick);
         }
-        catch (Exception e)
+
+        /// <summary>
+        /// 게스트 무팝업 자동 로그인(닉네임 재사용). 실패 시 UI로 폴백.
+        /// </summary>
+        private async Task TryAutoGuestAsync(string nickname)
         {
-            Debug.LogWarning($"[AuthBootstrapper] AutoGuest 실패: {e.Message}");
-            ShowLoginUI();
+            try
+            {
+                var auth = FirebaseAuth.DefaultInstance;
+                var res = await auth.SignInAnonymouslyAsync();
+                var user = res.User;
+                string nn = string.IsNullOrEmpty(nickname) ? defaultNick : nickname;
+
+                // (선택) DisplayName 업데이트로 Photon Nick 동기화 쉽게
+                await user.UpdateUserProfileAsync(new UserProfile { DisplayName = nn });
+
+                // ★ 단일 세션 시작
+                var enf = FindObjectOfType<SessionEnforcer>(true);
+                if (enf != null)
+                {
+                    var ok = await enf.StartForUidAsync(user.UserId);
+                    if (!ok)
+                    {
+                        ShowLoginUI();
+                        return;
+                    }
+                }
+
+                // 로컬 저장
+                AuthAccount.Remember("guest", user.UserId, nn);
+
+                ApplyPhotonAndStart(user.UserId, nn);
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AuthBootstrapper] AutoGuest 실패: {e.Message}");
+                ShowLoginUI();
+            }
         }
-    }
 
 #if UNITY_ANDROID && !UNITY_EDITOR
     /// <summary>
@@ -247,8 +250,10 @@ public class AuthBootstrapper : MonoBehaviour
     {
         try
         {
-            var active = (Social.Active as GooglePlayGames.PlayGamesPlatform) ?? GooglePlayGames.PlayGamesPlatform.Instance;
-            var mi = active?.GetType().GetMethod("GetIdToken", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+            var active =
+ (Social.Active as GooglePlayGames.PlayGamesPlatform) ?? GooglePlayGames.PlayGamesPlatform.Instance;
+            var mi =
+ active?.GetType().GetMethod("GetIdToken", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
             string idToken = mi != null ? (mi.Invoke(active, null) as string) : null;
 
             if (!string.IsNullOrEmpty(idToken))
@@ -279,71 +284,74 @@ public class AuthBootstrapper : MonoBehaviour
     }
 #endif
 
-    /// <summary>
-    /// Photon 인증값/닉네임 설정 → 네트워크/게임 부트 이어주기
-    /// </summary>
-    private void ApplyPhotonAndStart(string uid, string nickname)
-    {
-        PhotonNetwork.NickName = string.IsNullOrEmpty(nickname) ? defaultNick : nickname;
+        /// <summary>
+        /// Photon 인증값/닉네임 설정 → 네트워크/게임 부트 이어주기
+        /// </summary>
+        private void ApplyPhotonAndStart(string uid, string nickname)
+        {
+            PhotonNetwork.NickName = string.IsNullOrEmpty(nickname) ? defaultNick : nickname;
 
-        // Photon UserId는 AuthenticationValues에 주입(서버에서 식별용)
-        PhotonNetwork.AuthValues = new Photon.Realtime.AuthenticationValues(uid);
+            // Photon UserId는 AuthenticationValues에 주입(서버에서 식별용)
+            PhotonNetwork.AuthValues = new Photon.Realtime.AuthenticationValues(uid);
 
-        // (선택) 바로 연결/로비 진입이 GameBootstrap/NetworkManager에 숨어 있다면 해당 진입점을 생성
-        new GameObject("GameBootstrap", typeof(GameStartBootstrap));
+            // (선택) 바로 연결/로비 진입이 GameBootstrap/NetworkManager에 숨어 있다면 해당 진입점을 생성
+            Util_LDH.ConsoleLog(this, "------------Game Start Bootstrap을 만듭니다. -----------");
+            new GameObject("GameStartBootstrap", typeof(GameStartBootstrap));
 
-        if (verbose) Debug.Log($"[AuthBootstrapper] Ready → UID={uid}, Nick={nickname}");
+            if (verbose) Debug.Log($"[AuthBootstrapper] Ready → UID={uid}, Nick={nickname}");
+        }
+
+        /// <summary>로그인 UI(게스트/GPGS 선택창)를 띄웁니다.</summary>
+        private void ShowLoginUI()
+        {
+            var ui = FindObjectOfType<KYG.GuestLoginUI>(true);
+            if (ui) ui.ShowLoginChoice();
+            else Debug.LogWarning("[AuthBootstrapper] GuestLoginUI를 찾지 못했습니다.");
+        }
+
+        /// <summary>
+        /// 전역 네트워크 보강 오브젝트들 자동 보장:
+        /// - UidPersistenceGuard (LocalPlayer uid 누락 자동 보정)
+        /// - PlayerDirectory + PlayerDirectoryBinder (UID ↔ Player 매핑)
+        /// - SessionEnforcer, SessionKickGuard (단일 세션 + 킥 오버레이)
+        /// </summary>
+        private void EnsureGlobalNetGlueObjects()
+        {
+            // 1) UID 보정 가드
+            if (FindObjectOfType<UidPersistenceGuard>(true) == null)
+            {
+                var go = new GameObject("UidPersistenceGuard", typeof(UidPersistenceGuard));
+                DontDestroyOnLoad(go);
+            }
+
+            // 2) PlayerDirectory + Binder
+            if (FindObjectOfType<KYG.Net.PlayerDirectory>(true) == null)
+            {
+                var dir = new GameObject("PlayerDirectory", typeof(KYG.Net.PlayerDirectory));
+                DontDestroyOnLoad(dir);
+            }
+
+            if (FindObjectOfType<PlayerDirectoryBinder>(true) == null)
+            {
+                var bd = new GameObject("PlayerDirectoryBinder", typeof(PlayerDirectoryBinder));
+                DontDestroyOnLoad(bd);
+            }
+
+            // 3) SessionEnforcer
+            if (FindObjectOfType<SessionEnforcer>(true) == null)
+            {
+                var se = new GameObject("SessionEnforcer", typeof(SessionEnforcer));
+                DontDestroyOnLoad(se);
+                // 에디터에서 SessionEnforcer.databaseUrl 필드에 URL 지정해두면 좋아요.
+            }
+
+            // 4) SessionKickGuard (오버레이 프리팹은 인스펙터에서 할당)
+            if (FindObjectOfType<SessionKickGuard>(true) == null)
+            {
+                var kg = new GameObject("SessionKickGuard", typeof(SessionKickGuard));
+                DontDestroyOnLoad(kg);
+                // 인스펙터에서 overlayPrefab 슬롯에 SessionKickOverlay 프리팹을 넣으세요.
+            }
+        }
     }
-
-    /// <summary>로그인 UI(게스트/GPGS 선택창)를 띄웁니다.</summary>
-    private void ShowLoginUI()
-    {
-        var ui = FindObjectOfType<KYG.GuestLoginUI>(true);
-        if (ui) ui.ShowLoginChoice();
-        else Debug.LogWarning("[AuthBootstrapper] GuestLoginUI를 찾지 못했습니다.");
-    }
-
-    /// <summary>
-    /// 전역 네트워크 보강 오브젝트들 자동 보장:
-    /// - UidPersistenceGuard (LocalPlayer uid 누락 자동 보정)
-    /// - PlayerDirectory + PlayerDirectoryBinder (UID ↔ Player 매핑)
-    /// - SessionEnforcer, SessionKickGuard (단일 세션 + 킥 오버레이)
-    /// </summary>
-    private void EnsureGlobalNetGlueObjects()
-    {
-        // 1) UID 보정 가드
-        if (FindObjectOfType<UidPersistenceGuard>(true) == null)
-        {
-            var go = new GameObject("UidPersistenceGuard", typeof(UidPersistenceGuard));
-            DontDestroyOnLoad(go);
-        }
-        // 2) PlayerDirectory + Binder
-        if (FindObjectOfType<KYG.Net.PlayerDirectory>(true) == null)
-        {
-            var dir = new GameObject("PlayerDirectory", typeof(KYG.Net.PlayerDirectory));
-            DontDestroyOnLoad(dir);
-        }
-        if (FindObjectOfType<PlayerDirectoryBinder>(true) == null)
-        {
-            var bd = new GameObject("PlayerDirectoryBinder", typeof(PlayerDirectoryBinder));
-            DontDestroyOnLoad(bd);
-        }
-        // 3) SessionEnforcer
-        if (FindObjectOfType<SessionEnforcer>(true) == null)
-        {
-            var se = new GameObject("SessionEnforcer", typeof(SessionEnforcer));
-            DontDestroyOnLoad(se);
-            // 에디터에서 SessionEnforcer.databaseUrl 필드에 URL 지정해두면 좋아요.
-        }
-        // 4) SessionKickGuard (오버레이 프리팹은 인스펙터에서 할당)
-        if (FindObjectOfType<SessionKickGuard>(true) == null)
-        {
-            var kg = new GameObject("SessionKickGuard", typeof(SessionKickGuard));
-            DontDestroyOnLoad(kg);
-            // 인스펙터에서 overlayPrefab 슬롯에 SessionKickOverlay 프리팹을 넣으세요.
-        }
-    }
-
-    -
-}
 }

--- a/Assets/KYG/KYG_Scripts/Auth/GPGSLoginManager.cs
+++ b/Assets/KYG/KYG_Scripts/Auth/GPGSLoginManager.cs
@@ -11,6 +11,8 @@ using Photon.Realtime;
 using UnityEngine;
 using UnityEngine.SocialPlatforms;
 using System.Threading.Tasks;
+using LDH_Util;
+using PMS_Util;
 
 namespace KYG.Auth
 {
@@ -47,7 +49,7 @@ namespace KYG.Auth
         public void LoginWithGPGS()
         {
             PreflightLog();
-#if UNITY_ANDROID && !UNITY_EDITOR
+// #if UNITY_ANDROID && !UNITY_EDITOR
             PlayGamesPlatform.Instance.Authenticate(status =>
             {
                 if (status != SignInStatus.Success)
@@ -83,9 +85,9 @@ namespace KYG.Auth
                     TryIdTokenFallback(displayName);
                 }
             });
-#else
+// #else
             Debug.LogWarning("[GPGS] Android 기기에서 테스트하세요. (에디터 미지원)");
-#endif
+// #endif
         }
 
         /// <summary>GetIdToken 공개 API가 없는 환경을 위한 리플렉션 폴백</summary>
@@ -185,7 +187,8 @@ namespace KYG.Auth
             
             
             //game 리소스 다운 / 초기화 및 파이어베이스 데이터 로드 진행 후 서버로 연결하기 위해 game boot strap을 생성한다.
-            GameObject gameBootstrap = new GameObject("Game Bootstrap", typeof(GameStartBootstrap));
+            Util_LDH.ConsoleLog(this, "------------Game Start Bootstrap을 만듭니다. -----------");
+            GameObject gameBootstrap = new GameObject("GameStartBootstrap", typeof(GameStartBootstrap));
             
             // if (!PhotonNetwork.IsConnected) PhotonNetwork.ConnectUsingSettings();
             // else if (!PhotonNetwork.InLobby && PhotonNetwork.NetworkClientState != ClientState.JoiningLobby) // 방어로직 추가
@@ -205,7 +208,7 @@ namespace KYG.Auth
 
             PhotonNetwork.NickName = nickname;
             PhotonNetwork.AuthValues = new Photon.Realtime.AuthenticationValues(uid);
-            new GameObject("Game Bootstrap", typeof(GameStartBootstrap));
+            // new GameObject("Game Bootstrap", typeof(GameStartBootstrap));
         }
 
         public override void OnConnectedToMaster()

--- a/Assets/KYG/KYG_Scripts/Auth/GameBootstrap.cs
+++ b/Assets/KYG/KYG_Scripts/Auth/GameBootstrap.cs
@@ -62,7 +62,7 @@ public class GameBootstrap : MonoBehaviourPunCallbacks
         // (OnConnectedToMaster에서 체크해서 JoinLobby 호출)
         
         // 게임 부트스트랩을 돌려줘야 합니다. (초기화 및 데이터 정보 가져온 후에 포톤 네트워크에 연결해서 로비로 이동시켜야 합니다. 이 일을 모두 GameBootstrap에서 처리합니다.)
-        GameObject gameBootstrap = new GameObject("GameStartBootstrap", typeof(GameStartBootstrap));
+        // GameObject gameBootstrap = new GameObject("GameStartBootstrap", typeof(GameStartBootstrap));
     }
 
     public override void OnConnectedToMaster()

--- a/Assets/KYG/KYG_Scripts/Auth/GuestLoginManager.cs
+++ b/Assets/KYG/KYG_Scripts/Auth/GuestLoginManager.cs
@@ -11,6 +11,7 @@ using UnityEngine;
 using Network;
 using System.Threading.Tasks;
 using LDH_Game;
+using LDH_Util;
 
 
 namespace KYG.Auth
@@ -331,7 +332,8 @@ namespace KYG.Auth
             Debug.Log($"[GuestLogin] Photon.AuthValues.UserId={PhotonNetwork.AuthValues?.UserId}");
 
             //game 리소스 다운 / 초기화 및 파이어베이스 데이터 로드 진행 후 서버로 연결하기 위해 game boot strap을 생성한다.(bootstrap 이 완료되면 자동으로 서버연결이 됩니다)
-            GameObject gameBootstrap = new GameObject("GameBootstrap", typeof(GameStartBootstrap));
+            Util_LDH.ConsoleLog(this, "------------Game Start Bootstrap을 만듭니다. -----------");
+            GameObject gameBootstrap = new GameObject("GameStartBootstrap", typeof(GameStartBootstrap));
             
             
             
@@ -446,7 +448,8 @@ namespace KYG.Auth
             // 3) Photon 값 주입 + 네트워크 부트
             PhotonNetwork.NickName = nickname;
             PhotonNetwork.AuthValues = new Photon.Realtime.AuthenticationValues(uid);
-            new GameObject("Game Bootstrap", typeof(GameStartBootstrap));
+            Util_LDH.ConsoleLog(this, "------------Game Start Bootstrap을 만듭니다. -----------");
+            new GameObject("GameStartBootstrap", typeof(GameStartBootstrap));
         }
 
         /// <summary>

--- a/Assets/LDH/LDH_Scripts/MainGame/MainGameManager/MainGame_UIBinder.cs
+++ b/Assets/LDH/LDH_Scripts/MainGame/MainGameManager/MainGame_UIBinder.cs
@@ -209,9 +209,15 @@ namespace LDH_MainGame
 
         public async UniTask ShowGameEnd(bool isMainEnd = false)
         {
-            //미니게임 씬의 event system 비활성화시키기
-            EventSystem.current.enabled = false;
-
+            if(!isMainEnd)
+            {
+                EventSystem.current.enabled = false;
+            }
+            else
+            {
+                Debug.Log("<color=red> 이벤트 시스템 안끕니다.</color>");
+            }
+         
             //열려있는 모든 팝업 닫기
             await Manager.UI.CloseAllPopupUI();
 
@@ -254,8 +260,7 @@ namespace LDH_MainGame
         }
 
         public async UniTask ShowRewardPopup(GamePlayer localPlayer)
-        {
-            _rewardPanel = Manager.UI.CreatePopupUI<UI_Popup_Reward>();
+        { _rewardPanel = Manager.UI.CreatePopupUI<UI_Popup_Reward>();
             await _rewardPanel.SetData(localPlayer);
             await Manager.UI.ShowPopupUI(_rewardPanel);
         }

--- a/Assets/LDH/LDH_Scripts/Network/NetworkManager.cs
+++ b/Assets/LDH/LDH_Scripts/Network/NetworkManager.cs
@@ -92,13 +92,13 @@ namespace Network
                 return true;
             }
 
-            // C) 로그인/타이틀 씬에서는 자동 접속 금지
-            string scene = SceneManager.GetActiveScene().name;
-            if (scene.Contains("Login") || scene.Contains("Title"))
-            {
-                Debug.Log("[NetworkManager] skip auto-connect in Login/Title scene");
-                return true;
-            }
+            // // C) 로그인/타이틀 씬에서는 자동 접속 금지
+            // string scene = SceneManager.GetActiveScene().name;
+            // if (scene.Contains("Login") || scene.Contains("Title"))
+            // {
+            //     Debug.Log("[NetworkManager] skip auto-connect in Login/Title scene");
+            //     return true;
+            // }
 
             // D) Firebase 인증이 아직 없으면 자동 접속 금지
             var auth = FirebaseAuth.DefaultInstance;
@@ -359,7 +359,7 @@ namespace Network
             // 커스텀 프로퍼티 설정
             if (!PhotonNetwork.LocalPlayer.CustomProperties.ContainsKey("uid"))
             {
-//                Debug.Log("프로퍼티 - uid를 설정합니다.");
+                 // Debug.Log("프로퍼티 - uid를 설정합니다.");
                 var props = new Hashtable { { "uid", PhotonNetwork.AuthValues?.UserId }, };
                 PhotonNetwork.LocalPlayer.SetCustomProperties(props);
             }


### PR DESCRIPTION
# 🧑‍💻 PR

## 💻 버그 해결방법 (Fix 전용)

### 🔧 수정된 버그
<!--
예) 아이템 호버링, 사운드 누락
-->

1. GPGS 로그인 이후 로비 진입이 안되는 문제, 자동로그인에서 로비 진입이 안되는 문제 수정
    - 로그인 담당 기능들을 로그인 인증만 처리하고 로그인이 성공하면 GameStartBootstrap(기존에 제가 만든 GameBootstrap이 다른 클래스와 이름이 겹쳐서 GameStartBootstrap으로 변경하였습니다.)을 생성하여 게임 부트스트랩이 어드레서블 초기화, 데이터 불러오기, 각종 매니저 초기화를 진행한 후 -> 최종적으로 포톤 네트워크에 연결하면 -> NetworkManager에서 자동으로 로비로 진입을 처리하도록 했습니다.
    - 기존에 로그인, 로그아웃 코드에 작성되어 있는 서버 접속 및 로비 진입 부분이 네트워크 매니저와 충돌해 오류가 나 주석처리하였습니다.
    - 수정 후에도, 자동 로그인에서 로그인 성공 후 로비 진입이 되지 않고 로비 씬에 머물러 있어 NetworkManager에 자동 진업을 방지하는 부분에서 '로비 씬'이나 '타이틀 씬'이면 로비로 진입하지 않는다는 부분을 주석처리하여 제대로 로비로 진입할 수 있게 했습니다.
    - GPGS 로그인 버튼을 누르면 처음 GameStartBootstrap이 생성되어 로딩창이 나타나면 초기화가 진행되는데, 또 다시 로딩창이 한 번 더 뜨면서 로비로 진입했음에도 불구하고 로딩창이 내려가지 않는 문제가 있었습니다.(자동로그인에서는 발생하지 않음). 로그를 찍어보니 GPGS 로그인 시도 시에 GameStartBoostrap을 두 번 생성하고 있었습니다. onClick 구독을 인스펙터에서도 1번, 코드에서도 1번 하고 있어 총 2번 호출되는 것이 원인이었고, 인스펙터에서 구독하고 있는 부분을 제거하였더니 정상 동작했습니다.

2. 보상창 버튼이 작동하지 않는 오류.
    - 미니게임이 종료되고 난 후 '게임 종료' UI 가 나오는데 이 때 잠깐 찰나에 설정 버튼을 누르면 설정 팝업이 뜨면서 메인 맵으로 돌아와서도 설정이 계속 켜져있고 닫히지 않는 문제가 있었습니다. 메인 게임 상태가 변할 때 모든 팝업을 닫게 처리하는 방식으로 수정했지만, 버튼을 광클하면 그 찰나에 설정창이 눌릴 수 있습니다.
    - 그래서 미니게임 종료 UI가 뜰 때 event system을 비활성화하고 추후에 활성화하는 방식을 선택했는데, 해당 UI를 매칭이 종료될 때 '매칭 종료'에서도 동일하게 사용한다는 것을 깜박해서 이때 비활성화 한 event system을 다시 복구시키지 않았습니다.
    - 그 결과 보상창 버튼을 아무리 눌러도 작동하지 않는 버그가 발생했습니다. 매칭 종료일 때 미니게임 종료 UI와 다른 텍스트를 띄우기 위해 조건을 분기해서 처리하는 부분이 있어서 해당 조건일 때는 event system을 비활성화 하지 않도록 변경하여 문제를 해결했습니다.

### ✔️ 버그 체크리스트
- [x] 추가로 수정이 필요함
- [x] 수정 완료
- [ ] QA 테스트 통과

## 💬 기타 사항
- 추가로 옷장에서 아이템 가격이 0원일 때 아무런 표기가 나타나지 않는 문제를 발견했습니다. 제가 0원일 때를 생각하지 못하고, 0원이면 데이터가 없다는 걸로 구현해서 발생한 문제인 것 같습니다. 이 부분은 내일 중으로 수정하도록 하겠습니다.