### PR TITLE
[Feat] 리듬 게임 판정바 로직 추가

### DIFF
--- a/Assets/KST/Materials/LaneCubeMaterial.mat
+++ b/Assets/KST/Materials/LaneCubeMaterial.mat
@@ -1,0 +1,138 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-8244226236752313146
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: LaneCubeMaterial
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _ALPHAPREMULTIPLY_ON
+  - _SPECULAR_SETUP
+  - _SURFACE_TYPE_TRANSPARENT
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
+  disabledShaderPasses:
+  - DepthOnly
+  - SHADOWCASTER
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 10
+    - _DstBlendAlpha: 10
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 1
+    - _WorkflowMode: 0
+    - _ZWrite: 0
+    m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 0.27450982}
+    - _Color: {r: 1, g: 1, b: 1, a: 0.27450982}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/KST/Materials/LaneCubeMaterial.mat.meta
+++ b/Assets/KST/Materials/LaneCubeMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 07e5c77740bb06743b64c6c4401679f8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KST/Scenes/Rhythm.unity
+++ b/Assets/KST/Scenes/Rhythm.unity
@@ -1415,7 +1415,7 @@ MonoBehaviour:
   - {fileID: 351156399658851704, guid: 8b50fe8b38e93ff45868f9fd191da9bb, type: 3}
   _hitEffect:
   - {fileID: -2183472396014260670, guid: 33cbbf70a735d40c09095dad893fe459, type: 3}
-  - {fileID: 820710234137249982, guid: cc4edba986607ba48b17927b27d25e4e, type: 3}
+  - {fileID: -9122617242247568557, guid: cc4edba986607ba48b17927b27d25e4e, type: 3}
   speed: 20
   _songBpm: 160
   _songOffsetSec: 0
@@ -1617,7 +1617,7 @@ PrefabInstance:
     - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.0304414
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 873450919960001178, guid: b4f2cd633f84448609793082bcf66d70,
         type: 3}
@@ -2464,9 +2464,14 @@ MonoBehaviour:
   - {fileID: 281150528}
   - {fileID: 348252279}
   - {fileID: 1534204817}
-  playerVerdictPoints: []
+  playerVerdictPoints:
+  - {fileID: 1946492246}
+  - {fileID: 1784050621}
+  - {fileID: 1644965635}
+  - {fileID: 1677164762}
   playerPrefabName: Prefabs/Rhythm/RhythmUnimo
   backupPrefabName: Prefabs/Rhythm/RhythmPlayer
+  playerVerdictPrefab: Prefabs/Rhythm/LaneCube
   tempSpawnPos: {x: 0, y: 0, z: 0}
 --- !u!4 &771616244
 Transform:
@@ -3248,7 +3253,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 34.677963, y: 1.2000008}
+  m_AnchoredPosition: {x: 25, y: 1.2000008}
   m_SizeDelta: {x: 98.4777, y: 37.7403}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1077306839
@@ -3631,7 +3636,7 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 1, y: 4, z: 2.5}
+  m_Size: {x: 1, y: 4, z: 4}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!54 &1196916484
 Rigidbody:
@@ -3912,7 +3917,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 1909852908}
+  m_Material: {fileID: 1439892236}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
@@ -4004,6 +4009,46 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1872738575}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!21 &1439892236
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
+    - _WidthHeightRadius: {r: 149.651, g: 51.939, b: 40, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1001 &1473781510
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4376,7 +4421,7 @@ Transform:
   m_GameObject: {fileID: 1644965634}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -1}
+  m_LocalPosition: {x: 0.25, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -4407,7 +4452,7 @@ Transform:
   m_GameObject: {fileID: 1677164761}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -2, y: 0, z: -1}
+  m_LocalPosition: {x: -1.5, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -5227,46 +5272,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!21 &1909852908
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
-    - _WidthHeightRadius: {r: 149.651, g: 51.939, b: 40, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1001 &1918526450
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5437,7 +5442,7 @@ Transform:
   m_GameObject: {fileID: 1946492245}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 4, y: 0, z: -1}
+  m_LocalPosition: {x: 3.75, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -5573,9 +5578,9 @@ SceneRoots:
   - {fileID: 771616244}
   - {fileID: 682961389}
   - {fileID: 1872738575}
+  - {fileID: 1358550686}
   - {fileID: 2021070405}
   - {fileID: 1196916487}
-  - {fileID: 1358550686}
   - {fileID: 457379607}
   - {fileID: 1941556641}
   - {fileID: 305406254}

--- a/Assets/KST/Scenes/Rhythm.unity
+++ b/Assets/KST/Scenes/Rhythm.unity
@@ -905,7 +905,7 @@ Transform:
   m_GameObject: {fileID: 281150527}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 2, y: 0, z: 1}
+  m_LocalPosition: {x: 2, y: 0, z: 1.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1141,7 +1141,7 @@ Transform:
   m_GameObject: {fileID: 348252278}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.25, y: 0, z: 1}
+  m_LocalPosition: {x: 0.25, y: 0, z: 1.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2862,6 +2862,46 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 944378920}
   m_PrefabAsset: {fileID: 0}
+--- !u!21 &1014671538
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
+    - _WidthHeightRadius: {r: 149.651, g: 51.939, b: 40, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1 &1027446214
 GameObject:
   m_ObjectHideFlags: 0
@@ -3636,8 +3676,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 1, y: 4, z: 4}
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 4, z: 3}
+  m_Center: {x: 0, y: 0, z: -0.2}
 --- !u!54 &1196916484
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -3724,7 +3764,7 @@ Transform:
   m_GameObject: {fileID: 1196916479}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.1, y: 2.5, z: -5}
+  m_LocalPosition: {x: 1.1, y: 2.5, z: -5.24}
   m_LocalScale: {x: 6.8, y: 1, z: 1.45}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3917,7 +3957,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 1439892236}
+  m_Material: {fileID: 1014671538}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
@@ -4003,52 +4043,12 @@ Transform:
   m_GameObject: {fileID: 1376969139}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 3.75, y: 0, z: 1}
+  m_LocalPosition: {x: 3.75, y: 0, z: 1.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1872738575}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!21 &1439892236
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
-    - _WidthHeightRadius: {r: 149.651, g: 51.939, b: 40, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1001 &1473781510
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4359,7 +4359,7 @@ Transform:
   m_GameObject: {fileID: 1534204816}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -1.5, y: 0, z: 1}
+  m_LocalPosition: {x: -1.5, y: 0, z: 1.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -4421,7 +4421,7 @@ Transform:
   m_GameObject: {fileID: 1644965634}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.25, y: 0, z: -1}
+  m_LocalPosition: {x: 0.25, y: 0, z: -1.55}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -4452,7 +4452,7 @@ Transform:
   m_GameObject: {fileID: 1677164761}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -1.5, y: 0, z: -1}
+  m_LocalPosition: {x: -1.5, y: 0, z: -1.55}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -4651,7 +4651,7 @@ Transform:
   m_GameObject: {fileID: 1784050620}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 2, y: 0, z: -1}
+  m_LocalPosition: {x: 2, y: 0, z: -1.55}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -5442,7 +5442,7 @@ Transform:
   m_GameObject: {fileID: 1946492245}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 3.75, y: 0, z: -1}
+  m_LocalPosition: {x: 3.75, y: 0, z: -1.55}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/KST/Scripts/RhythmGame/Manager/GameManager.cs
+++ b/Assets/KST/Scripts/RhythmGame/Manager/GameManager.cs
@@ -48,7 +48,7 @@ namespace RhythmGame
         [Header("플레이어 프리팹 이름")]
         [SerializeField] string playerPrefabName = "Prefabs/Rhythm/RhythmUnimo";
         [SerializeField] string backupPrefabName = "Prefabs/Rhythm/RhythmPlayer"; //테스트용
-        // [SerializeField] string playerVerdictPrefab = "Prefabs/Rhythm/VerdictModel"; //테스트용
+        [SerializeField] string playerVerdictPrefab = "Prefabs/Rhythm/LaneCube"; //테스트용
         [SerializeField] Vector3 tempSpawnPos = Vector3.zero; // 임시 스폰 위치
 
 
@@ -80,7 +80,7 @@ namespace RhythmGame
             InitializePlayers();
             //테스트 환경에서 리소스 없는 것을 방지
             var prefab = Resources.Load<GameObject>(playerPrefabName);
-            // var verdictPrefab = Resources.Load<GameObject>(playerVerdictPrefab);
+            var verdictPrefab = Resources.Load<GameObject>(playerVerdictPrefab);
             if (prefab == null)
             {
                 Debug.Log($"{playerPrefabName}가 없어서 {backupPrefabName}로 플레이어 캐릭터 모델 변경 ");
@@ -90,7 +90,7 @@ namespace RhythmGame
             PhotonNetwork.Instantiate(playerPrefabName, tempSpawnPos, Quaternion.identity);
 
             //판정바 생성
-            // PhotonNetwork.Instantiate(playerVerdictPrefab, tempSpawnPos, Quaternion.identity);
+            PhotonNetwork.Instantiate(playerVerdictPrefab, tempSpawnPos, Quaternion.identity);
         }
 
         #region 게임 시작 종료 로직
@@ -347,23 +347,23 @@ namespace RhythmGame
                 StartCoroutine(IE_DelayPlace(actorNumber, lane));
                 return;
             }
-            // //플레이어 컨트롤러가 액터 넘버 기준으로 딕셔너리에 등록돼 있는지 확인
-            // if (!PlayerVerdict.VerdictByActor.TryGetValue(actorNumber, out var vt))
-            // {
-            //     //아닐 경우 코루틴으로 지연 후 확인
-            //     StartCoroutine(IE_DelayVerdictPlace(actorNumber, lane));
-            //     return;
-            // }
+            //플레이어 컨트롤러가 액터 넘버 기준으로 딕셔너리에 등록돼 있는지 확인
+            if (!PlayerVerdict.VerdictByActor.TryGetValue(actorNumber, out var vt))
+            {
+                //아닐 경우 코루틴으로 지연 후 확인
+                StartCoroutine(IE_DelayVerdictPlace(actorNumber, lane));
+                return;
+            }
             //lane 인덱스 초과 방지
             int idx = Mathf.Clamp(lane - 1, 0, playerPoints.Length - 1);
 
             //해당 인덱스의 플레이어 위치 가져오기
             var p = playerPoints[idx];
-            // var vp = playerVerdictPoints[idx];
+            var vp = playerVerdictPoints[idx];
 
             //아바타 위치 해당 위치로 이동
             t.SetPositionAndRotation(p.position, p.rotation);
-            // vt.SetPositionAndRotation(vp.position, vp.rotation);
+            vt.SetPositionAndRotation(vp.position, vp.rotation);
         }
 
 
@@ -385,24 +385,24 @@ namespace RhythmGame
             }
             Debug.LogWarning($"액터넘버 : {actorNumber} 아바타를 찾지 못했습니다.");
         }
-        // IEnumerator IE_DelayVerdictPlace(int actorNumber, int lane)
-        // {
-        //     //최대 10번 시도
-        //     for (int i = 0; i < 10; i++)
-        //     {
-        //         yield return new WaitForSeconds(0.1f);
+        IEnumerator IE_DelayVerdictPlace(int actorNumber, int lane)
+        {
+            //최대 10번 시도
+            for (int i = 0; i < 10; i++)
+            {
+                yield return new WaitForSeconds(0.1f);
 
-        //         //아바타가 딕셔너리에 등록돼 있다면 배치 진행
-        //         if (PlayerVerdict.VerdictByActor.TryGetValue(actorNumber, out var t))
-        //         {
-        //             int idx = Mathf.Clamp(lane - 1, 0, playerVerdictPoints.Length - 1);
-        //             var p = playerVerdictPoints[idx];
-        //             t.SetPositionAndRotation(p.position, p.rotation);
-        //             yield break;
-        //         }
-        //     }
-        //     Debug.LogWarning($"액터넘버 : {actorNumber} 판정바를 찾지 못했습니다.");
-        // }
+                //아바타가 딕셔너리에 등록돼 있다면 배치 진행
+                if (PlayerVerdict.VerdictByActor.TryGetValue(actorNumber, out var t))
+                {
+                    int idx = Mathf.Clamp(lane - 1, 0, playerVerdictPoints.Length - 1);
+                    var p = playerVerdictPoints[idx];
+                    t.SetPositionAndRotation(p.position, p.rotation);
+                    yield break;
+                }
+            }
+            Debug.LogWarning($"액터넘버 : {actorNumber} 판정바를 찾지 못했습니다.");
+        }
 
         public Pose GetLaneSpawnPose(int lane)
         {

--- a/Assets/KST/Scripts/RhythmGame/Manager/GameManager.cs
+++ b/Assets/KST/Scripts/RhythmGame/Manager/GameManager.cs
@@ -88,7 +88,7 @@ namespace RhythmGame
             }
             // 캐릭터 생성
             PhotonNetwork.Instantiate(playerPrefabName, tempSpawnPos, Quaternion.identity);
-            
+
             //판정바 생성
             // PhotonNetwork.Instantiate(playerVerdictPrefab, tempSpawnPos, Quaternion.identity);
         }
@@ -110,7 +110,7 @@ namespace RhythmGame
             Debug.Log("모든 플레이어의 커스터마이징이 완료될때까지 대기");
             yield return new WaitUntil(() => customedPlayer.Count == PhotonNetwork.CurrentRoom.PlayerCount);
             Debug.Log("모든 플레이어의 커스터마이징 완료");
-            
+
             // 플레이어 자리 배정
             LaneManager.Instance.SetLane();
 
@@ -155,7 +155,7 @@ namespace RhythmGame
         IEnumerator IE_WaitStart(double startTime, double endTime)
         {
             while (PhotonNetwork.Time < startTime) yield return null;
-
+            if (IsGameOver) yield return null;
 
             if (PhotonNetwork.IsMasterClient)
             {
@@ -219,7 +219,6 @@ namespace RhythmGame
                 BroadcastRankSnapshot(rankings);
                 SendResultToMainGame(rankings);
             }
-
 
             //게임 종료 이벤트 호출
             OnGameOver?.Invoke();
@@ -649,6 +648,6 @@ namespace RhythmGame
         }
 
         #endregion
-        
+
     }
 }

--- a/Assets/KST/Scripts/RhythmGame/Player/PlayerLaneCube.cs
+++ b/Assets/KST/Scripts/RhythmGame/Player/PlayerLaneCube.cs
@@ -1,0 +1,70 @@
+using System.Linq;
+using Photon.Pun;
+using UnityEngine;
+
+namespace RhythmGame
+{
+    [RequireComponent(typeof(PhotonView))]
+    [RequireComponent(typeof(Renderer))]
+    public class PlayerLaneCube : MonoBehaviour
+    {
+        [SerializeField] Renderer _renderer;
+        [SerializeField, Range(0f, 1f)] float alphaValue = 0.8f;
+        JengaRankingUIAnimated provider;
+
+        string _uid;
+        MaterialPropertyBlock _mpb;
+        PhotonView _pv;
+
+        readonly int ID_BaseColor = Shader.PropertyToID("_BaseColor");
+
+        void Awake()
+        {
+            _pv = GetComponent<PhotonView>();
+
+            if (!provider) provider = FindObjectOfType<JengaRankingUIAnimated>();
+            if (_renderer == null)
+                _renderer = GetComponent<Renderer>();
+
+            _mpb = new MaterialPropertyBlock();
+
+            _uid = _pv && _pv.Owner != null
+                ? _pv.Owner.CustomProperties?["uid"] as string
+                : null;
+
+            if (provider)
+                provider.OnPaletteChanged += HandlePaletteChanged;
+        }
+
+        void Start()
+        {
+            ApplyNow();
+        }
+
+        void OnDestroy()
+        {
+            if (provider)
+                provider.OnPaletteChanged -= HandlePaletteChanged;
+        }
+
+        void HandlePaletteChanged() => ApplyNow();
+
+        public void ApplyNow()
+        {
+            if (string.IsNullOrEmpty(_uid) || provider == null || _renderer == null) return;
+
+            if (!provider.TryGetColor(_uid, out var c))
+                return;
+
+            c.a = Mathf.Clamp01(alphaValue);
+            ApplyRenderer(_renderer, c);
+        }
+
+        void ApplyRenderer(Renderer r, Color color)
+        {
+            r.GetPropertyBlock(_mpb);
+            _mpb.SetColor(ID_BaseColor, color);
+            r.SetPropertyBlock(_mpb);
+        }
+    }
+}

--- a/Assets/KST/Scripts/RhythmGame/Player/PlayerLaneCube.cs.meta
+++ b/Assets/KST/Scripts/RhythmGame/Player/PlayerLaneCube.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ee47873559d4fa46861601bec380669
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KST/Scripts/RhythmGame/UI/TimerUI.cs
+++ b/Assets/KST/Scripts/RhythmGame/UI/TimerUI.cs
@@ -66,7 +66,7 @@ namespace RhythmGame
             _countDownText.gameObject.SetActive(false);
             _gameStartText.gameObject.SetActive(false);
             _timerText.gameObject.SetActive(true);
-            _timerText.text = "00:00";
+            _timerText.text = "00";
 
         }
 

--- a/Assets/Resources/Prefabs/Rhythm/LaneCube.prefab
+++ b/Assets/Resources/Prefabs/Rhythm/LaneCube.prefab
@@ -31,7 +31,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -1.5, y: 3.16, z: -4.95}
-  m_LocalScale: {x: 1.5, y: 1, z: 1.45}
+  m_LocalScale: {x: 1.5, y: 1, z: 4.35}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -98,12 +98,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0ee47873559d4fa46861601bec380669, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  provider: {fileID: 0}
-  targets:
-  - {fileID: 8254584189675607107}
-  targetAlpha: 0.8
-  affectEmission: 0
-  emissionIntensity: 1
+  _renderer: {fileID: 0}
+  alphaValue: 0.5
 --- !u!114 &7245257875748441556
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/Rhythm/LaneCube.prefab
+++ b/Assets/Resources/Prefabs/Rhythm/LaneCube.prefab
@@ -1,0 +1,140 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2561246048499431561
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5752900595450211212}
+  - component: {fileID: 8862770343167665997}
+  - component: {fileID: 8254584189675607107}
+  - component: {fileID: -6027431996695220097}
+  - component: {fileID: 7245257875748441556}
+  - component: {fileID: -7147770234149859572}
+  m_Layer: 0
+  m_Name: LaneCube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5752900595450211212
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2561246048499431561}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.5, y: 3.16, z: -4.95}
+  m_LocalScale: {x: 1.5, y: 1, z: 1.45}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8862770343167665997
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2561246048499431561}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8254584189675607107
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2561246048499431561}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 07e5c77740bb06743b64c6c4401679f8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &-6027431996695220097
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2561246048499431561}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ee47873559d4fa46861601bec380669, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  provider: {fileID: 0}
+  targets:
+  - {fileID: 8254584189675607107}
+  targetAlpha: 0.8
+  affectEmission: 0
+  emissionIntensity: 1
+--- !u!114 &7245257875748441556
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2561246048499431561}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 0
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
+--- !u!114 &-7147770234149859572
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2561246048499431561}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dfff8b9f7b2ba7842a6e192ca8f13e80, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Resources/Prefabs/Rhythm/LaneCube.prefab.meta
+++ b/Assets/Resources/Prefabs/Rhythm/LaneCube.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0907ae0422987e045910623a60b097fd
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# 🧑‍💻 PR

## 🔥 작업 내용 요약
1. 개인 판정 바 시각화
-> 판정바 자체의 시각화를 추가적으로 작업하기 위해
플레이어 각 개인 별 색상을 추가로 부여하여 세팅
2. 게임 종료시 타이머의 시간이 00이 아닌 00:00으로 변함.
-> 00:00 텍스트를 00으로 변환
<br>



## ✅ PR 체크리스트
- [ ] 빌드 오류 없음
- [ ] 기능 정상 작동 확인
- [ ] 커밋 메시지 규칙 준수
- [ ] Scene 충돌 없음

## 💬 기타 사항
- 리뷰어에게 공유하고 싶은 내용