### PR TITLE
[Fix] 타이밍 게임 오류 수정 (난이도 증가 로직 변경 &  모바일에서 타이밍 판정 오류 & 사운드 저장 이슈)

### DIFF
--- a/Assets/KST/Scripts/Jenga/TimingGame.cs
+++ b/Assets/KST/Scripts/Jenga/TimingGame.cs
@@ -16,6 +16,29 @@ public class TimingGame : MonoBehaviour
     [SerializeField] GameObject _finishPanel; //성공, 실패 여부 패널
     [SerializeField] TMP_Text _finishText;
 
+    [Header("난이도 UI")]
+    [SerializeField] TMP_Text _speedLevelText;
+    [SerializeField] TMP_Text _zoneLevelText;
+
+    [Header("난이도 레벨별 색상 (0~4단계)")]
+    [SerializeField]
+    private Color[] levelColors = new Color[4]
+{
+    Color.black,                // 레벨 0: 검정
+    Color.green,                // 레벨 1: 초록
+    Color.yellow,               // 레벨 2: 노랑
+    new Color(1f, 0.5f, 0f)    // 레벨 3: 주황  
+};
+
+    [Header("깜빡임 설정")]
+    [SerializeField] private Color blinkColor = Color.cyan; // 깜빡일 때 색상
+    [SerializeField] private int blinkCount = 3;
+    [SerializeField] private float blinkSpeed = 0.2f;
+
+    private int _currentSpeedLevel = 0;
+    private int _currentZoneLevel = 0;
+    private int _prevSpeedLevel = 0;
+    private int _prevZoneLevel = 0;
 
     [Header("타이밍 세팅")]
     [SerializeField] float _limitTime = 5f; // 제한시간
@@ -27,12 +50,16 @@ public class TimingGame : MonoBehaviour
     [SerializeField]
     float _zoneHeight = 40f;                          // 성공존 세로 높이(px)
 
-
     bool _isRun = false; // 게임 실행 여부
     float _remainTime; // 잔여 시간
     float _pingPongTimer;
     float _zoneW;
     public event Action<bool, float> OnFinished; // 성공여부 이벤트
+
+    [Header("판정 설정")]
+    [SerializeField, Range(0f, 1f)]
+    private float requiredOverlapRatio = 0.5f; // 성공 판정에 필요한 겹침 비율 (0.5 = 50%)
+
 
     void Awake() => Init();
 
@@ -65,14 +92,6 @@ public class TimingGame : MonoBehaviour
         _slider.maxValue = 100f;
         _slider.value = 0f;
 
-        //슬라이더 핸들 크기(별 크기) 조절
-        RectTransform handle = _slider.handleRect;
-
-        float handleW = _sliderRect.rect.width * 0.15f;
-        float handleH = _sliderRect.rect.height * 0.15f;
-
-        handle.sizeDelta = new(handleW, handleH);
-
         //텍스트 초기화
         _timeText.text = "";
 
@@ -104,6 +123,8 @@ public class TimingGame : MonoBehaviour
 
         _remainTime = _limitTime;
         _timeText.text = Mathf.CeilToInt(_remainTime).ToString();
+
+        UpdateDifficultyUI(); // UI 갱신
     }
 
     /// <summary>
@@ -120,6 +141,10 @@ public class TimingGame : MonoBehaviour
             _successZone.SetParent(slideArea, worldPositionStays: false);
         }
 
+        // 앵커를 중앙으로 강제 설정
+        _successZone.anchorMin = new Vector2(0.5f, 0.5f);
+        _successZone.anchorMax = new Vector2(0.5f, 0.5f);
+        _successZone.pivot = new Vector2(0.5f, 0.5f);
 
         float w = slideArea ? slideArea.rect.width : _sliderRect.rect.width;
         _zoneW = w * _zoneWRate;
@@ -127,14 +152,24 @@ public class TimingGame : MonoBehaviour
         // 가로폭은 비율, 세로 높이는 인스펙터 값 사용
         _successZone.sizeDelta = new(_zoneW, _zoneHeight);
 
-        // 중앙 배치
-        _successZone.anchoredPosition = Vector2.right * ((w - _zoneW) * 0.5f);
+        _successZone.anchoredPosition = Vector2.zero;
 
         // 그리기 순서: 성공존 뒤, 핸들 앞
         _successZone.SetSiblingIndex(0);                 // 성공존을 맨 뒤로
         _slider.handleRect.SetAsLastSibling();           // 핸들을 맨 앞으로
 
         _successZone.gameObject.SetActive(true);
+
+        if (slideArea)
+        {
+            var sliderCorners = new Vector3[4];
+            slideArea.GetWorldCorners(sliderCorners);
+            Debug.Log($"슬라이더 전체 범위: {sliderCorners[0].x:F2} ~ {sliderCorners[2].x:F2}");
+        }
+
+        var corners = new Vector3[4];
+        _successZone.GetWorldCorners(corners);
+        Debug.Log($"성공존 실제 범위: {corners[0].x:F2} ~ {corners[2].x:F2}");
     }
 
     public IEnumerator IE_CountDownPublic() => IE_CountDown(); // JengaTimingManager에서 코루틴이 접근하도록 수정
@@ -159,23 +194,54 @@ public class TimingGame : MonoBehaviour
     (bool isSuccess, float accuracy) Calculate()
     {
         var handleGraphic = _slider.handleRect.GetComponentInChildren<Image>()?.rectTransform
-                            ?? _slider.handleRect;
+                         ?? _slider.handleRect;
 
-        float handleCenterX = GetWorldCenterX(handleGraphic);
+        // 핸들의 월드 코너
+        var handleCorners = new Vector3[4];
+        handleGraphic.GetWorldCorners(handleCorners);
+        float handleLeft = handleCorners[0].x;
+        float handleRight = handleCorners[2].x;
+        float handleCenter = 0.5f * (handleLeft + handleRight);
 
-        var z = new Vector3[4];
-        _successZone.GetWorldCorners(z);
-        float start = z[0].x;   // left
-        float end   = z[3].x;   // right
-        float center = 0.5f * (start + end);
-        float half   = 0.5f * (end - start);
+        var zoneCorners = new Vector3[4];
+        _successZone.GetWorldCorners(zoneCorners);
+        float zoneLeft = zoneCorners[0].x;
+        float zoneRight = zoneCorners[2].x;
+        float zoneCenter = 0.5f * (zoneLeft + zoneRight);
+        float zoneHalfWidth = 0.5f * (zoneRight - zoneLeft);
 
-        bool inside = (start <= handleCenterX) && (handleCenterX <= end);
-        if (!inside) return (false, 0f);
+        // 겹치는 영역 계산
+        float overlapLeft = Mathf.Max(handleLeft, zoneLeft);
+        float overlapRight = Mathf.Min(handleRight, zoneRight);
+        float overlapWidth = Mathf.Max(0f, overlapRight - overlapLeft);
 
-        float acc = 1f - Mathf.Clamp01(Mathf.Abs(handleCenterX - center) / half);
+        float handleWidth = handleRight - handleLeft;
+        float overlapRatio = handleWidth > 0 ? (overlapWidth / handleWidth) : 0f;
+
+        // Inspector에서 설정한 비율 이상 겹쳐야 성공
+        if (overlapRatio < requiredOverlapRatio) return (false, 0f);
+
+        // 정확도 계산
+        float centerDistance = Mathf.Abs(handleCenter - zoneCenter);
+        float acc = 1f - Mathf.Clamp01(centerDistance / zoneHalfWidth);
 
         return (true, acc);
+
+        #region Removed Code
+        //var z = new Vector3[4];
+        //_successZone.GetWorldCorners(z);
+        //float start = z[0].x;   // left
+        //float end   = z[3].x;   // right
+        //float center = 0.5f * (start + end);
+        //float half   = 0.5f * (end - start);
+
+        //bool inside = (start <= handleCenterX) && (handleCenterX <= end);
+        //if (!inside) return (false, 0f);
+
+        //float acc = 1f - Mathf.Clamp01(Mathf.Abs(handleCenterX - center) / half);
+
+        //return (true, acc);
+        #endregion
     }
 
     /// <summary>
@@ -183,7 +249,7 @@ public class TimingGame : MonoBehaviour
     /// </summary>
     /// <param name="isSuccess">성공 여부</param>
     /// <param name="accuracy">정확도 </param>
-   void GameEnd(bool isSuccess, float accuracy)
+    void GameEnd(bool isSuccess, float accuracy)
     {
         if (!_isRun) return;
         _isRun = false;
@@ -233,6 +299,8 @@ public class TimingGame : MonoBehaviour
         //랜덤으로 아래 중 하나 고르기
         bool type = UnityEngine.Random.Range(0, 2) == 0;
         bool isChnaged = type ? DescSpeed(level) || DescZone(level) : DescZone(level) || DescSpeed(level);
+
+        UpdateDifficultyUI();
     }
 
 
@@ -251,6 +319,7 @@ public class TimingGame : MonoBehaviour
         if (after < before)
         {
             _speed = after;
+            _currentSpeedLevel = level; // 현재 속도 레벨 저장
             return true;
         }
         return false;
@@ -271,10 +340,82 @@ public class TimingGame : MonoBehaviour
         if (after < before)
         {
             _zoneWRate = after;
+            _currentZoneLevel = level; // 현재 영역 레벨 저장
             return true;
         }
         return false;
     }
+
+    #region 난이도 증가 UI
+    private void UpdateDifficultyUI()
+    {
+        // 속도 UI 업데이트
+        if (_speedLevelText != null)
+        {
+            string speedLabel = GetLevelLabel(_currentSpeedLevel);
+            _speedLevelText.text = $"속도: {speedLabel}";
+
+            Color baseColor = GetLevelColor(_currentSpeedLevel);
+            _speedLevelText.color = baseColor;
+
+            // 레벨이 증가했으면 깜빡임
+            if (_currentSpeedLevel > _prevSpeedLevel)
+            {
+                StartCoroutine(BlinkText(_speedLevelText, baseColor));
+                _prevSpeedLevel = _currentSpeedLevel;
+            }
+        }
+
+        // 성공존 UI 업데이트
+        if (_zoneLevelText != null)
+        {
+            string zoneLabel = GetLevelLabel(_currentZoneLevel);
+            _zoneLevelText.text = $"성공존: {zoneLabel}";
+
+            Color baseColor = GetLevelColor(_currentZoneLevel);
+            _zoneLevelText.color = baseColor;
+
+            // 레벨이 증가했으면 깜빡임
+            if (_currentZoneLevel > _prevZoneLevel)
+            {
+                StartCoroutine(BlinkText(_zoneLevelText, baseColor));
+                _prevZoneLevel = _currentZoneLevel;
+            }
+        }
+    }
+
+    private string GetLevelLabel(int level)
+    {
+        switch (level)
+        {
+            case 0: return "기본";
+            case 1: return "1단계";
+            case 2: return "2단계";
+            case 3: return "MAX";
+            default: return "MAX";
+        }
+    }
+
+    private Color GetLevelColor(int level)
+    {
+        if (level >= 0 && level < levelColors.Length)
+            return levelColors[level];
+
+        return levelColors[levelColors.Length - 1];
+    }
+
+    private IEnumerator BlinkText(TMP_Text text, Color originalColor)
+    {
+        for (int i = 0; i < blinkCount; i++)
+        {
+            text.color = blinkColor;
+            yield return new WaitForSeconds(blinkSpeed);
+            text.color = originalColor;
+            yield return new WaitForSeconds(blinkSpeed);
+        }
+    }
+
+    #endregion
 
     float GetWorldCenterX(RectTransform rt)
     {

--- a/Assets/KST/Scripts/Util/Enums/SoundManager.cs
+++ b/Assets/KST/Scripts/Util/Enums/SoundManager.cs
@@ -70,8 +70,8 @@ public class SoundManager : CombinedSingleton<SoundManager>
     #endregion
 
     // 볼륨
-    public float bgmSoundVolume { get; private set; } = 1f;
-    public float sfxSoundVolume { get; private set; } = 1f;
+    public float bgmSoundVolume { get; private set; } = 0.5f;
+    public float sfxSoundVolume { get; private set; } = 0.5f;
 
     #region 최적화
 
@@ -98,7 +98,6 @@ public class SoundManager : CombinedSingleton<SoundManager>
     {
         base.Awake();
         InitializeAudioSources();
-        LoadVolumeSettings();
         BuildMaps();
 
         SceneManager.sceneLoaded += OnSceneLoaded;
@@ -106,10 +105,17 @@ public class SoundManager : CombinedSingleton<SoundManager>
 
         //활성 씬 변경 감지
         SceneManager.activeSceneChanged += OnActiveSceneChanged;
+    }
 
+    private async void Start()
+    {
+        await UniTask.Yield();
 
-        // 타이틀 사운드로 초기화
-        //LoadGameSounds(GameType.Title);
+        LoadVolumeSettings();
+
+        await UniTask.Yield();
+        SetBGMSoundVolume(bgmSoundVolume);
+        SetSFXSoundVolume(sfxSoundVolume);
     }
 
     protected override void OnDestroy()
@@ -393,6 +399,9 @@ public class SoundManager : CombinedSingleton<SoundManager>
         }
 
         PlayerPrefs.SetFloat("BGMVolume", volume);
+        PlayerPrefs.Save();
+
+        Debug.Log($"<color=yellow>BGM 볼륨 저장됨: {volume}</color>");
     }
 
     public void SetSFXSoundVolume(float volume)
@@ -421,6 +430,7 @@ public class SoundManager : CombinedSingleton<SoundManager>
         }
 
         PlayerPrefs.SetFloat("SFXVolume", volume);
+        PlayerPrefs.Save();
     }
 
     #endregion
@@ -593,6 +603,8 @@ public class SoundManager : CombinedSingleton<SoundManager>
     {
         bgmSoundVolume = PlayerPrefs.GetFloat("BGMVolume", 1f);
         sfxSoundVolume = PlayerPrefs.GetFloat("SFXVolume", 1f);
+
+        Debug.Log($"<color=cyan>PlayerPrefs 로드됨 - BGM: {bgmSoundVolume}, SFX: {sfxSoundVolume}</color>");
 
         SetBGMSoundVolume(bgmSoundVolume);
         SetSFXSoundVolume(sfxSoundVolume);

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaTimingManager/JengaTimingManager.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaTimingManager/JengaTimingManager.cs
@@ -124,11 +124,12 @@ namespace MiniGameJenga
             var tower = JengaTowerManager.Instance?.GetPlayerTower(block.OwnerActorNumber);
             if (tower != null)
             {
-                int removedCount = tower.GetRemovedBlocksCount();
-                Debug.Log($"[JengaTimingManager] 타이밍 시작 - 제거된 블록 수: {removedCount}");
+                // 2개 이상 제거된 층의 개수로 난이도 결정
+                int completedLayers = tower.GetCompletedLayersCount();
 
-                // 타이밍 게임에 제거된 블록 수 기반으로 난이도 적용
-                ui.DifficultyChange(removedCount);
+                Debug.Log($"[JengaTimingManager] 타이밍 시작 - 완료된 층: {completedLayers}, 난이도 레벨: {completedLayers}");
+
+                ui.DifficultyChange(completedLayers);
             }
 
             // 이벤트 연결 + GameStart
@@ -137,8 +138,6 @@ namespace MiniGameJenga
 
             // 매니저에서 코루틴 시작
             _countdownCo = StartCoroutine(ui.IE_CountDownPublic());
-
-            Debug.Log($"[JengaTimingManager] Timing game started for block: {block.name}");
         }
 
         private static void ActivateHierarchy(GameObject go)

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaTower/JengaTower.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaTower/JengaTower.cs
@@ -128,6 +128,33 @@ public class JengaTower : MonoBehaviour
         return false;
     }
 
+    #region 타이밍 게임 난이도 증가 관련 메서드
+    /// <summary>
+    /// 2개 이상의 블록이 제거된 층의 개수를 반환
+    /// </summary>
+    public int GetCompletedLayersCount()
+    {
+        int completedLayers = 0;
+
+        foreach (var kv in _blocksByLayer)
+        {
+            int layer = kv.Key;
+            var blocksInLayer = kv.Value;
+
+            // 이 층에서 제거된 블록 수 계산
+            int removedInThisLayer = blocksInLayer.Count(b => b.IsRemoved);
+
+            // 2개 이상 제거되었으면 "완료된 층"으로 카운트
+            if (removedInThisLayer >= 2)
+            {
+                completedLayers++;
+            }
+        }
+
+        return completedLayers;
+    }
+    #endregion
+
     public void InitializeOwner(int actorNumber, string uid)
     {
         ownerActorNumber = actorNumber;

--- a/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaUIManager/JengaUIManager.cs
+++ b/Assets/LTH/LTH_Scripts/MiniGame_Jenga/JengaUIManager/JengaUIManager.cs
@@ -8,7 +8,6 @@ using Photon.Pun;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
-using DG.Tweening;
 
 public class JengaUIManager : CombinedSingleton<JengaUIManager>, IGameComponent
 {
@@ -252,15 +251,10 @@ public class JengaUIManager : CombinedSingleton<JengaUIManager>, IGameComponent
             if (remainingTime > 0f && remainingTime <= 10f)
             {
                 timerText.color = Color.red;
-
-                timerText.transform.DOKill();
-                timerText.transform.DOShakePosition(0.5f, 3f, 20, 45f, false, true)
-                    .SetLoops(-1, LoopType.Restart);
             }
             else
             {
                 timerText.color = Color.black;
-                timerText.transform.DOKill();
             }
         }
     }

--- a/Assets/Resources/Prefabs/Jenga/TimingUI/TimingGame.prefab
+++ b/Assets/Resources/Prefabs/Jenga/TimingUI/TimingGame.prefab
@@ -1,5 +1,140 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &770474153627256177
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6070293768765111138}
+  - component: {fileID: 6413827863899062569}
+  - component: {fileID: 8254792204646176030}
+  m_Layer: 5
+  m_Name: SpeedText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &6070293768765111138
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 770474153627256177}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 852286118062853595}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -177, y: 187.734}
+  m_SizeDelta: {x: 340.61, y: 116.73}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6413827863899062569
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 770474153627256177}
+  m_CullTransparentMesh: 1
+--- !u!114 &8254792204646176030
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 770474153627256177}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uC18D\uB3C4 : \uAE30\uBCF8"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 263a5f6c8c323c84e9bd6ede05411f99, type: 2}
+  m_sharedMaterial: {fileID: -363288562218260364, guid: 263a5f6c8c323c84e9bd6ede05411f99,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 45
+  m_fontSizeBase: 45
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &792557072500720335
 GameObject:
   m_ObjectHideFlags: 0
@@ -34,8 +169,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 375.97043, y: 8.597983}
-  m_SizeDelta: {x: 274.555, y: 38.124996}
+  m_AnchoredPosition: {x: 263, y: 4.631}
+  m_SizeDelta: {x: 280.505, y: 30.191}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &3518430212016448013
 CanvasRenderer:
@@ -58,14 +193,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 0.9564916, b: 0, a: 1}
+  m_Color: {r: 1, g: 0.9830959, b: 0.0056602955, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 9320dce57bba0e346afa7da9d1a62ae6, type: 3}
+  m_Sprite: {fileID: 21300000, guid: ae874d0e07fafe74ea90a24eb74d594a, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -242,13 +377,15 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5239062226954905732}
+  - {fileID: 6070293768765111138}
+  - {fileID: 264259480595546710}
   - {fileID: 5785091928008755468}
   m_Father: {fileID: 8589680871353180694}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -332}
-  m_SizeDelta: {x: 1275.0493, y: 849.3999}
+  m_AnchoredPosition: {x: 19.568, y: -442.883}
+  m_SizeDelta: {x: 914.133, y: 627.632}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6050505980961436369
 CanvasRenderer:
@@ -336,8 +473,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 23.015, y: 0.0000076293945}
-  m_SizeDelta: {x: -46.029, y: -0}
+  m_AnchoredPosition: {x: 2.5003052, y: -1.2399979}
+  m_SizeDelta: {x: -5, y: -37.185}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2252702367935943595
 GameObject:
@@ -463,9 +600,9 @@ RectTransform:
   m_Father: {fileID: 135158097020506926}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 10, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: -2.5, y: 0}
+  m_SizeDelta: {x: 5, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5479734905116681310
 CanvasRenderer:
@@ -539,8 +676,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -160.68103}
-  m_SizeDelta: {x: 500, y: 500}
+  m_AnchoredPosition: {x: 0.00041848, y: -135.072}
+  m_SizeDelta: {x: 888.04, y: 344.436}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4503199643103156572
 CanvasRenderer:
@@ -674,8 +811,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.25}
   m_AnchorMax: {x: 1, y: 0.75}
-  m_AnchoredPosition: {x: -2, y: 2.2870026}
-  m_SizeDelta: {x: -20, y: -48.186}
+  m_AnchoredPosition: {x: -2, y: 4.968}
+  m_SizeDelta: {x: -20, y: -9.936}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &3487643431365064913
 GameObject:
@@ -712,8 +849,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.212, y: 49}
-  m_SizeDelta: {x: 1108.24, y: 334.062}
+  m_AnchoredPosition: {x: 0.212, y: 38.129}
+  m_SizeDelta: {x: 788.906, y: 312.32}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &3844659367483618457
 MonoBehaviour:
@@ -833,7 +970,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 1ab991fddcacd914a9b4d337a1a7c9b4, type: 2}
+  m_Sprite: {fileID: 21300000, guid: a191f75cec4d2b744972d2320950c871, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -862,10 +999,21 @@ MonoBehaviour:
   _sliderGo: {fileID: 1798959895516087386}
   _finishPanel: {fileID: 9180759222254172223}
   _finishText: {fileID: 3188471450813400666}
+  _speedLevelText: {fileID: 8254792204646176030}
+  _zoneLevelText: {fileID: 4442061637176116630}
+  levelColors:
+  - {r: 0, g: 0, b: 0, a: 1}
+  - {r: 0.3457636, g: 0.6981132, b: 0.3457636, a: 1}
+  - {r: 0.8301887, g: 0.78494424, b: 0.26237094, a: 1}
+  - {r: 1, g: 0.5, b: 0, a: 1}
+  blinkColor: {r: 1, g: 0.015686274, b: 0.034767997, a: 1}
+  blinkCount: 3
+  blinkSpeed: 0.2
   _limitTime: 5
   _speed: 1.6
   _zoneWRate: 0.45
-  _zoneHeight: 40
+  _zoneHeight: 150
+  requiredOverlapRatio: 0.51
 --- !u!1 &4303016769436054638
 GameObject:
   m_ObjectHideFlags: 0
@@ -884,7 +1032,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &894374716221063315
 RectTransform:
   m_ObjectHideFlags: 0
@@ -944,9 +1092,9 @@ MonoBehaviour:
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 1440, y: 3088}
+  m_ReferenceResolution: {x: 1080, y: 1920}
   m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
+  m_MatchWidthOrHeight: 0.5
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
@@ -1077,9 +1225,9 @@ RectTransform:
   m_Father: {fileID: 5350269549133495501}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 16.57, y: 6.375}
-  m_SizeDelta: {x: 186.456, y: 62.275}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 29.710999, y: 11}
+  m_SizeDelta: {x: 187.419, y: 82.248}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2441048520949197381
 CanvasRenderer:
@@ -1109,7 +1257,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: b37addafa99f0c94f8386f51a192ff78, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 1a80d59fd376247d89c992b71c8d5f8b, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -1119,6 +1267,141 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8512495086220595018
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 264259480595546710}
+  - component: {fileID: 1190026521258904085}
+  - component: {fileID: 4442061637176116630}
+  m_Layer: 5
+  m_Name: SuccessZoneText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &264259480595546710
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8512495086220595018}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 852286118062853595}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 157, y: 187.734}
+  m_SizeDelta: {x: 340.61, y: 116.73}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1190026521258904085
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8512495086220595018}
+  m_CullTransparentMesh: 1
+--- !u!114 &4442061637176116630
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8512495086220595018}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uC131\uACF5\uC874 : \uAE30\uBCF8"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 263a5f6c8c323c84e9bd6ede05411f99, type: 2}
+  m_sharedMaterial: {fileID: -363288562218260364, guid: 263a5f6c8c323c84e9bd6ede05411f99,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 45
+  m_fontSizeBase: 45
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &9180759222254172223
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/MiniGameJengaScene.unity
+++ b/Assets/Scenes/MiniGameJengaScene.unity
@@ -2072,7 +2072,7 @@ MonoBehaviour:
   m_CameraActivatedEvent:
     m_PersistentCalls:
       m_Calls: []
---- !u!21 &343969044
+--- !u!21 &353721895
 Material:
   serializedVersion: 8
   m_ObjectHideFlags: 0
@@ -2109,8 +2109,8 @@ Material:
     - _StencilWriteMask: 255
     - _UseUIAlphaClip: 0
     m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
-    - _WidthHeightRadius: {r: 149.651, g: 51.939, b: 40, a: 0}
+    - _OuterUV: {r: 0.024052067, g: 0.022535274, b: 0.9789449, a: 0.9755116}
+    - _WidthHeightRadius: {r: 1192.5742, g: 319.42212, b: 80, a: 0}
   m_BuildTextureStacks: []
 --- !u!1 &363694452
 GameObject:
@@ -5417,46 +5417,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 629855328}
   m_PrefabAsset: {fileID: 0}
---- !u!21 &646730227
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0.024052067, g: 0.022535274, b: 0.9789449, a: 0.9755116}
-    - _WidthHeightRadius: {r: 1192.5742, g: 319.42212, b: 80, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1 &669275689
 GameObject:
   m_ObjectHideFlags: 0
@@ -6406,46 +6366,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 704486632}
   m_PrefabAsset: {fileID: 0}
---- !u!21 &722878545
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 0.99999994, a: 1}
-    - _WidthHeightRadius: {r: 914.133, g: 627.632, b: 80, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1001 &748278359
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7222,7 +7142,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 343969044}
+  m_Material: {fileID: 1850677449}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
@@ -7934,6 +7854,46 @@ Transform:
   m_Children: []
   m_Father: {fileID: 859200890}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!21 &930177199
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 0.99999994, a: 1}
+    - _WidthHeightRadius: {r: 914.133, g: 627.632, b: 80, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1 &938219809
 GameObject:
   m_ObjectHideFlags: 0
@@ -8506,46 +8466,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1220913738}
   m_CullTransparentMesh: 1
---- !u!21 &1242948487
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 0.99999994, a: 1}
-    - _WidthHeightRadius: {r: 1275.0493, g: 849.3999, b: 80, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1 &1259499494
 GameObject:
   m_ObjectHideFlags: 0
@@ -11090,36 +11010,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 712919546302733117, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 792557072500720335, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 852286118062853595, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 914.133
-      objectReference: {fileID: 0}
-    - target: {fileID: 852286118062853595, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 627.632
-      objectReference: {fileID: 0}
-    - target: {fileID: 852286118062853595, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 19.568
-      objectReference: {fileID: 0}
-    - target: {fileID: 852286118062853595, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -442.883
-      objectReference: {fileID: 0}
     - target: {fileID: 894374716221063315, guid: 2ef4c95d678195e479f8489a2227c5c5,
         type: 3}
       propertyPath: m_Pivot.x
@@ -11220,152 +11110,21 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1715407823972043507, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1715407823972043507, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 160
-      objectReference: {fileID: 0}
-    - target: {fileID: 1715407823972043507, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 62
-      objectReference: {fileID: 0}
-    - target: {fileID: 1715407823972043507, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 16
-      objectReference: {fileID: 0}
-    - target: {fileID: 1715407823972043507, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 2582669928173800608, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4092835515707982058, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: a191f75cec4d2b744972d2320950c871,
-        type: 3}
     - target: {fileID: 4303016769436054638, guid: 2ef4c95d678195e479f8489a2227c5c5,
         type: 3}
       propertyPath: m_Name
       value: TimingGame
       objectReference: {fileID: 0}
-    - target: {fileID: 4303016769436054638, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5239062226954905732, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 888.04
-      objectReference: {fileID: 0}
-    - target: {fileID: 5239062226954905732, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 344.436
-      objectReference: {fileID: 0}
-    - target: {fileID: 5239062226954905732, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0.00041848
-      objectReference: {fileID: 0}
-    - target: {fileID: 5239062226954905732, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -135.072
-      objectReference: {fileID: 0}
-    - target: {fileID: 5350269549133495501, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: -4.9996
-      objectReference: {fileID: 0}
-    - target: {fileID: 5350269549133495501, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5350269549133495501, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 2.5003052
-      objectReference: {fileID: 0}
-    - target: {fileID: 5506821264504152005, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_MatchWidthOrHeight
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5506821264504152005, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_ReferenceResolution.x
-      value: 1080
-      objectReference: {fileID: 0}
-    - target: {fileID: 5506821264504152005, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_ReferenceResolution.y
-      value: 1920
-      objectReference: {fileID: 0}
-    - target: {fileID: 5785091928008755468, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 788.906
-      objectReference: {fileID: 0}
-    - target: {fileID: 5785091928008755468, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 312.32
-      objectReference: {fileID: 0}
-    - target: {fileID: 5785091928008755468, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0.212
-      objectReference: {fileID: 0}
-    - target: {fileID: 5785091928008755468, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 38.129
-      objectReference: {fileID: 0}
     - target: {fileID: 7944304059464372922, guid: 2ef4c95d678195e479f8489a2227c5c5,
         type: 3}
       propertyPath: m_Material
       value: 
-      objectReference: {fileID: 1242948487}
+      objectReference: {fileID: 930177199}
     - target: {fileID: 8783747007911148679, guid: 2ef4c95d678195e479f8489a2227c5c5,
         type: 3}
       propertyPath: m_Material
       value: 
-      objectReference: {fileID: 1898194462}
-    - target: {fileID: 9215215364731363124, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 280.505
-      objectReference: {fileID: 0}
-    - target: {fileID: 9215215364731363124, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 30.191
-      objectReference: {fileID: 0}
-    - target: {fileID: 9215215364731363124, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 263
-      objectReference: {fileID: 0}
-    - target: {fileID: 9215215364731363124, guid: 2ef4c95d678195e479f8489a2227c5c5,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 4.631
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 353721895}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -11383,6 +11142,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7ad8cbc5154a7f8429da4c6fdb4c362b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!21 &1850677449
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
+    - _WidthHeightRadius: {r: 149.651, g: 51.939, b: 40, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1 &1867122145
 GameObject:
   m_ObjectHideFlags: 0
@@ -11458,46 +11257,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1867122145}
   m_CullTransparentMesh: 1
---- !u!21 &1898194462
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0.024052067, g: 0.022535274, b: 0.9789449, a: 0.9755116}
-    - _WidthHeightRadius: {r: 1192.5742, g: 319.42212, b: 80, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1 &1932304810
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
# 🧑‍💻 PR

## 🔗 관련 이슈
- 수행한 작업과 관련 작업 번호를 작성해주세요 
- Related to: #95

## 🔥 작업 내용 요약
1. Fix - 난이도 증가 로직 변경
2. Fix - 모바일에서 타이밍 판정 오류
3. FIx - 사운드 저장 이슈

## 💻 버그 해결방법

### 💡 해결방법
#### 1. 난이도 증가 로직 수정
기존: 블록 1개 제거마다 난이도 즉시 증가
블록 4개만 제거해도 최대 난이도 도달 (너무 급격한 상승)

변경 : 한 층(2개) 완료 시에만 난이도 증가

#### 2.  모바일 타이밍 판정 정확도 개선

❌ 문제 상황
1. 성공존 위치 오류
Unity UI의 RectTransform은 Anchor 설정을 기준으로 위치를 계산 
기존 코드는 성공존의 Anchor가 특정 값(예: 왼쪽 끝)으로 설정되어 있다고 가정하고 위치를 계산했으나, 
Inspector에서 Anchor가 다르게 설정되어 있을 경우 성공 존이 의도하지 않은 위치에 배치

화면에 보이는 성공존의 위치와 실제 판정 좌표가 불일치
에디터에서는 특정 해상도에서 우연히 맞아 떨어져 정상 작동하는 것처럼 보임
모바일 기기의 다양한 화면 비율과 DPI에서 문제가 명확히 드러남

2. 판정 기준의 모호함
기존 판정 로직은 핸들(별)의 중심점만 확인하여 성공존 내부에 있는지 체크했습니다.

이 방식은 핸들의 실제 크기를 전혀 고려하지 않아 
핸들이 성공존에 70% 겹쳐도 중심이 밖에 있으면 실패
핸들이 성공존에 30%만 걸쳐도 중심이 안에 있으면 성공
모바일에서는 터치 입력의 정확도가 낮아 경계선 판정이 더욱 빈번하게 발생했습니다.

💡 해결 방안
1. 성공존 배치 안정화
코드에서 Anchor 설정을 명시적으로 중앙(0.5, 0.5)으로 강제 지정하여 Inspector 설정과 무관하게 항상 슬라이더 
중앙에 성공존이 배치되도록 수정하여 모든 해상도와 기기에서 동일한 판정

2. 판정 로직 개선
핸들의 중심점만 확인하는 대신, 핸들과 성공존이 실제로 겹치는 영역을 계산하는 방식으로 변경

핸들의 좌우 끝점과 성공존의 좌우 끝점을 각각 계산
두 영역이 겹치는 구간의 너비를 측정
핸들 전체 너비 대비 겹치는 비율을 계산
설정된 임계값(기본 50%) 이상 겹쳐야 성공으로 판정

requiredOverlapRatio 파라미터를 Inspector에 노출하여 판정 엄격도를 0~100% 범위에서 조절할 수 있도록 추가함 
이를 통해 게임의 난이도나 느낌에 맞게 판정 기준을 유연하게 조정


#### 3. 사운드 저장 이유
게임 시작 시 사운드가 저장이 안되고 따로 노는 느낌이 있었음

기존 코드 : 저장 코드는 있었으나 Awake에서 저장이 호출되어 Audio Mixer가 초기화 하기 전에 초기화가 되버리는 문제

수정 코드 : Start() 호출로 변경하여 초기화 순서가 올바르게 작동하도록 수정

### ✔️ 버그 체크리스트
- [ ] 추가로 수정이 필요함
- [x] 수정 완료
- [ ] QA 테스트 통과

## ✅ PR 체크리스트
- [x] 빌드 오류 없음
- [x] 기능 정상 작동 확인
- [x] 커밋 메시지 규칙 준수
- [x] Scene 충돌 없음