### PR TITLE
[Feat] 리듬게임 퍼펙트 판정 방식 변경

### DIFF
--- a/Assets/KST/Scenes/Rhythm.unity
+++ b/Assets/KST/Scenes/Rhythm.unity
@@ -2381,7 +2381,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isPersistent: 0
   verdictConfig:
-    touchPerfect: 0.2
+    touchPerfect: 0.725
     holdGood: 0.8
     verdictScoreMin: -10
     verdictScoreMax: 15
@@ -2400,6 +2400,46 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!21 &754104339
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
+    - _WidthHeightRadius: {r: 149.651, g: 51.939, b: 40, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1 &771616241
 GameObject:
   m_ObjectHideFlags: 0
@@ -2862,46 +2902,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 944378920}
   m_PrefabAsset: {fileID: 0}
---- !u!21 &1014671538
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
-    - _WidthHeightRadius: {r: 149.651, g: 51.939, b: 40, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1 &1027446214
 GameObject:
   m_ObjectHideFlags: 0
@@ -3957,7 +3957,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 1014671538}
+  m_Material: {fileID: 754104339}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}

--- a/Assets/KST/Scripts/RhythmGame/Manager/ScoreManager.cs
+++ b/Assets/KST/Scripts/RhythmGame/Manager/ScoreManager.cs
@@ -84,7 +84,7 @@ namespace RhythmGame
             var uid = PhotonNetwork.LocalPlayer.CustomProperties?["uid"] as string;
             if (string.IsNullOrEmpty(uid)) return;
 
-            GameManager.Instance.photonView.RPC(nameof(GameManager.RPC_ReceiveScore), RpcTarget.MasterClient, uid, _score, _verdictScore,perfectCount);
+            GameManager.Instance.photonView.RPC(nameof(GameManager.RPC_ReceiveScore), RpcTarget.MasterClient, uid, _score, _verdictScore, perfectCount);
         }
 
         #region RPC
@@ -128,13 +128,13 @@ namespace RhythmGame
 
         #region 판정관련 로직
         // 클라 → 마스터: 히트 요청(판정 포함)
-        public void RequestHit(int noteId, bool isCanInteract, NoteType type)
+        public void RequestHit(int noteId, bool isCanInteract, NoteType type, Verdict verdict)
         {
-            photonView.RPC(nameof(RPC_RequestHit), RpcTarget.MasterClient, noteId, isCanInteract, type);
+            photonView.RPC(nameof(RPC_RequestHit), RpcTarget.MasterClient, noteId, isCanInteract, type, verdict);
         }
 
         [PunRPC]
-        void RPC_RequestHit(int noteId, bool isCanInteract, NoteType type, PhotonMessageInfo info)
+        void RPC_RequestHit(int noteId, bool isCanInteract, NoteType type, Verdict verdict, PhotonMessageInfo info)
         {
             if (!PhotonNetwork.IsMasterClient) return;
 
@@ -146,37 +146,30 @@ namespace RhythmGame
             if (noteLane != actorLane) return;
             if (!LaneManager.Instance.LaneByNoteId.Remove(noteId)) return;
 
-            // 파괴
-            // LaneManager.Instance.LaneByNoteId.Remove(noteId);
-            NoteSpawner.Instance.DestroyNote(noteId, isCanInteract);
-
             // 득점 처리
-
             // 상호작용 불가능한 상태일 경우
             if (!isCanInteract)
-            {
-                GameManager.Instance.MissBlock(info.Sender, type);
-                return;
-            }
-            //상호작용 가능할 때
-            if (type == NoteType.Fake)
-            {
-                GameManager.Instance.GoodHitScore(type, info.Sender);
-            }
-            //속임수 노트가 아닐 경우
-            else
-            {
-                GameManager.Instance.GoodHitScore(type, info.Sender);
-                /*if (SoundManager.Instance != null)
-                    SoundManager.Instance.PlaySFX
-                    (type == NoteType.Continue ? "Continue" : "Touch");*/
+                verdict = Verdict.Miss;
 
+            // 파괴
+            NoteSpawner.Instance.DestroyNote(noteId, isCanInteract);
+
+            if (verdict == Verdict.Miss)
+                GameManager.Instance.MissBlock(info.Sender, type);
+            else
+                GameManager.Instance.GoodHitScore(type, info.Sender);
+
+            if (verdict != Verdict.Miss)
                 photonView.RPC(nameof(RPC_ExecuteSoundAction), info.Sender, type);
-            }
+            // else
+            // {
+            //     GameManager.Instance.GoodHitScore(type, info.Sender);
+            //     photonView.RPC(nameof(RPC_ExecuteSoundAction), info.Sender, type);
+            // }
         }
 
         // TODO - 확장성 있게 만들려면 
-        [PunRPC] 
+        [PunRPC]
         void RPC_ExecuteSoundAction(NoteType type)
         {
             if (SoundManager.Instance != null)
@@ -188,7 +181,7 @@ namespace RhythmGame
                 // TODO - 노트Type의 이름이랑 사운드 Key값이 같다는 가정하에
                 //SoundManager.Instance.PlaySFX(type.ToString());
             }
-        }             
+        }
 
         public void RequestMiss(NoteType noteType)
         {

--- a/Assets/KST/Scripts/RhythmGame/Manager/VerdictConfig.cs
+++ b/Assets/KST/Scripts/RhythmGame/Manager/VerdictConfig.cs
@@ -1,7 +1,7 @@
 [System.Serializable]
 public class VerdictConfig
 {
-    public float touchPerfect= 0.2f; //터치 블록 퍼펙트 판정 길이
+    public float touchPerfect= 0.725f; //터치 블록 퍼펙트 판정 길이
 
     public float holdGood = 0.8f; //80%정도만 해도 Good 판정해주기
 

--- a/Assets/KST/Scripts/RhythmGame/Player/RhythmPlayerInput.cs
+++ b/Assets/KST/Scripts/RhythmGame/Player/RhythmPlayerInput.cs
@@ -47,9 +47,11 @@ namespace RhythmGame
 
                 if (_holdTimer >= _requireHoldTime)
                 {
-                    ScoreManager.Instance.VerdictHold(_holdTimer, _requireHoldTime);
+                    var verdict = ScoreManager.Instance.VerdictHold(_holdTimer, _requireHoldTime);
+
                     NoteSpawner.Instance.ClientLocalHit(_holdTarget.NoteId);
-                    ScoreManager.Instance.RequestHit(_holdTarget.NoteId, true, NoteType.Continue);
+                    ScoreManager.Instance.RequestHit(_holdTarget.NoteId, true, NoteType.Continue, verdict);
+
                     _isDone = true;
                     InitHold();
                     InputCoolDown();
@@ -140,13 +142,13 @@ namespace RhythmGame
             if (_holdTarget != null)
             {
 
-                ScoreManager.Instance.VerdictHold(_holdTimer, _requireHoldTime);
+                var verdict = ScoreManager.Instance.VerdictHold(_holdTimer, _requireHoldTime);
 
                 bool success = _holdTimer >= _requireHoldTime && IsInVerdictBar(_holdTarget);
-                if (success)
+                if (success && verdict != Verdict.Miss)
                 {
                     NoteSpawner.Instance.ClientLocalHit(_holdTarget.NoteId);
-                    ScoreManager.Instance.RequestHit(_holdTarget.NoteId, true, NoteType.Continue);
+                    ScoreManager.Instance.RequestHit(_holdTarget.NoteId, true, NoteType.Continue,verdict);
                 }
                 else
                     ScoreManager.Instance.RequestMiss(NoteType.Continue);
@@ -169,12 +171,7 @@ namespace RhythmGame
                 NoteType? missType = null;
                 foreach (var t in _noteToTap)
                 {
-
-                    // t = _noteToTap;
-                    // _noteToTap = null;
-                    if (t == null) continue;
-
-                    if (t.Type == NoteType.Continue) continue;
+                    if (t == null || t.Type == NoteType.Continue) continue;
 
                     if (missType == null)
                         missType = t.Type;
@@ -183,10 +180,16 @@ namespace RhythmGame
 
                     if (isCan)
                     {
-                        ScoreManager.Instance.VerdictTouch(t, verdictNote.transform);
-                        NoteSpawner.Instance.ClientLocalHit(t.NoteId);
-                        ScoreManager.Instance.RequestHit(t.NoteId, true, t.Type);
-                        anyHit = true;
+                        var verdict = ScoreManager.Instance.VerdictTouch(t, verdictNote.transform);
+
+                        if (verdict != Verdict.Miss)
+                        {
+                            NoteSpawner.Instance.ClientLocalHit(t.NoteId);
+                            ScoreManager.Instance.RequestHit(t.NoteId, true, t.Type, verdict);
+                            anyHit = true;
+                        }
+                        else
+                            ScoreManager.Instance.RequestMiss(t.Type);
                     }
                 }
                 if (!anyHit && missType.HasValue)


### PR DESCRIPTION
# 🧑‍💻 PR

## 🔗 관련 이슈


## 🔥 작업 내용 요약
1. 기존 퍼펙트 판정 방식을 마스터 -> 로컬로 변경
2.  터치 노트 퍼펙트 범위를 +- 0.2 -> +-0.725(판정바 범위 만큼)으로 변경



## ✅ PR 체크리스트
- [ ] 빌드 오류 없음
- [ ] 기능 정상 작동 확인
- [ ] 커밋 메시지 규칙 준수
- [ ] Scene 충돌 없음

## 💬 기타 사항
- 리뷰어에게 공유하고 싶은 내용