### PR TITLE
[Fix] 기본 소유 목록 변경

### DIFF
--- a/Assets/LDH/LDH_Scripts/Data/CustomizationData.cs
+++ b/Assets/LDH/LDH_Scripts/Data/CustomizationData.cs
@@ -17,8 +17,8 @@ namespace Data
         public HashSet<string> ownedEquips;
         public long updatedAt; // 서버 시각(ms)
 
-        public IReadOnlyList<string> OwnedCharacters => ownedCharacters.ToList();
-        public IReadOnlyList<string> OwnedEquips => ownedEquips.ToList();
+        public IReadOnlyCollection<string> OwnedCharacters => ownedCharacters;
+        public IReadOnlyCollection<string> OwnedEquips => ownedEquips;
         public UnimoCombo CurrentCombo => new UnimoCombo(characterId, equipId);
         
         
@@ -52,12 +52,13 @@ namespace Data
             var defaultCharacterId =  Define_LDH.DefaultData.DefaultCharacter;
             var defaultEquipId     = Define_LDH.DefaultData.DefaultEquip;
             
+            
             return new CustomizationData
             {
                 characterId = defaultCharacterId,
                 equipId = defaultEquipId,
-                ownedCharacters = new() {  defaultCharacterId},
-                ownedEquips = new() { defaultEquipId },
+                ownedCharacters = new HashSet<string>(Define_LDH.DefaultData.DefaultOwnedCharacters),
+                ownedEquips     = new HashSet<string>(Define_LDH.DefaultData.DefaultOwnedEquips),
                 updatedAt  = 0 // 저장 시 서버타임으로 채움
             };
         }

--- a/Assets/LDH/LDH_Scripts/Utils/Define_LDH.cs
+++ b/Assets/LDH/LDH_Scripts/Utils/Define_LDH.cs
@@ -197,6 +197,10 @@ namespace LDH_Util
         {
             public const string DefaultCharacter = "unimo_ch_001";
             public const string DefaultEquip = "unimo_equip_001";
+            public static readonly IReadOnlyList<string> DefaultOwnedCharacters =
+                new List<string> { "unimo_ch_001", "unimo_ch_002" }.AsReadOnly();           
+            public static readonly IReadOnlyList<string> DefaultOwnedEquips= new[] { "unimo_equip_001", "unimo_equip_002" };
+
         }
 
         #endregion


### PR DESCRIPTION
# 🧑‍💻 PR

## 🔗 관련 이슈
- 수행한 작업과 관련 작업 번호를 작성해주세요 
<!--
- Resolves: #25 => PR 머지 시 해당 이슈 자동 닫힘
- Related to: #25 => 단순 연결, 자동 닫힘 없음
-->

## 🔥 작업 내용 요약
<!--
1. Feat - 플레이어 이동 구현
2. Fix - 아이템 복사 버그 수정
3. Comment - GameManager 코드 주석 설명 추가
-->
<br>

- 2번째 유니모, 엔진도 기본 소유 목록에 추가
