### PR TITLE
[Fix] 광고 시청 후 다음 게임에서 광고 버튼이 간헐적으로 비활성화되는 문제 해결

### DIFF
--- a/Assets/LTH/LTH_Scripts/AdMob/Manager/AdMobManager.cs
+++ b/Assets/LTH/LTH_Scripts/AdMob/Manager/AdMobManager.cs
@@ -156,7 +156,16 @@ public class AdMobManager : CombinedSingleton<AdMobManager>
     private void OnAdFailed(AdError error)
     {
         Debug.LogError($"[AdMob] Fullscreen failed: {error}");
+
+        if (_rewardedAd != null)
+        {
+            _rewardedAd.OnAdFullScreenContentFailed -= OnAdFailed;
+        }
+
         _rewardedAd = null;
+
+        // 실패 시에도 재로드
+        _ = LoadRewardedAsync();
     }
 
     /// <summary>
@@ -164,11 +173,14 @@ public class AdMobManager : CombinedSingleton<AdMobManager>
     /// </summary>
     public async Task<bool> ShowRewardedAsync(Action<Reward> onRewarded)
     {
-        if (!IsRewardedReady)
+        var adToShow = _rewardedAd;
+
+        if (adToShow == null || !adToShow.CanShowAd())
         {
             Debug.LogWarning("[AdMob] Rewarded not ready, try preload...");
             bool loaded = await LoadRewardedAsync();
-            if (!loaded || !IsRewardedReady)
+            adToShow = _rewardedAd;
+            if (adToShow == null || !adToShow.CanShowAd())
             {
                 Debug.LogError("[AdMob] Failed to load ad for show");
                 return false;
@@ -181,7 +193,7 @@ public class AdMobManager : CombinedSingleton<AdMobManager>
         {
             Debug.Log("[AdMob] Attempting to show rewarded ad...");
 
-            if (!_rewardedAd.CanShowAd())
+            if (!adToShow.CanShowAd())
             {
                 Debug.LogWarning("[AdMob] CanShowAd returned false");
                 return false;
@@ -193,17 +205,20 @@ public class AdMobManager : CombinedSingleton<AdMobManager>
             {
                 Debug.Log("[AdMob] Ad closed, cleaning up...");
 
-                if (_rewardedAd != null)
+                adToShow.OnAdFullScreenContentClosed -= closedHandler;
+
+                if (_rewardedAd == adToShow)
                 {
-                    _rewardedAd.OnAdFullScreenContentClosed -= closedHandler;
+                    _rewardedAd = null;
                 }
 
-                _rewardedAd = null;
+                _ = LoadRewardedAsync();
+
                 tcs.SetResult(true);
             };
 
-            _rewardedAd.OnAdFullScreenContentClosed += closedHandler;
-            _rewardedAd.Show(reward =>
+            adToShow.OnAdFullScreenContentClosed += closedHandler;
+            adToShow.Show(reward =>
             {
                 Debug.Log($"[AdMob] Reward received: {reward.Type}, Amount: {reward.Amount}");
                 onRewarded?.Invoke(reward);


### PR DESCRIPTION
# 🧑‍💻 PR

## 🔗 관련 이슈
- 수행한 작업과 관련 작업 번호를 작성해주세요 
- Related to: #164

## 🔥 작업 내용 요약
1. Fix - 광고 시청 후 다음 게임에서 광고 버튼이 간헐적으로 비활성화되는 문제 해결

## 💻 버그 해결방법

### 💡 해결방법

광고 닫힘/실패 시 자동 재로드 추가

ShowRewardedAsync - closedHandler
closedHandler = () =>
{
    // ...
    _rewardedAd = null;
    _ = LoadRewardedAsync(); // ✅ 추가: 다음 광고 미리 로드
    tcs.SetResult(true);
};


private void OnAdFailed(AdError error)
{
    // ...
    _rewardedAd = null;
    _ = LoadRewardedAsync(); // ✅ 추가: 실패 시에도 재로드
}

### ✔️ 버그 체크리스트
- [ ] 추가로 수정이 필요함
- [x] 수정 완료
- [ ] QA 테스트 통과

## ✅ PR 체크리스트
- [x] 빌드 오류 없음
- [x] 기능 정상 작동 확인
- [x] 커밋 메시지 규칙 준수
- [x] Scene 충돌 없음

## 💬 기타 사항
- 리뷰어에게 공유하고 싶은 내용