### PR TITLE
[Fix] UI 재수정 및 메인 게임에서 플레이어 이탈시 로직 정지 처리

### DIFF
--- a/Assets/LDH/LDH_Prefabs/UI/MainGame/ScoreEntry.prefab
+++ b/Assets/LDH/LDH_Prefabs/UI/MainGame/ScoreEntry.prefab
@@ -36,7 +36,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 13.64}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: -2, y: 55}
+  m_AnchoredPosition: {x: -2, y: 42}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &1807485728657046080
@@ -964,9 +964,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7114109535116862991}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 50, y: -50}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3370725894430050415

--- a/Assets/LDH/LDH_Scripts/MainGame/MainGameManager/MainGameManager.cs
+++ b/Assets/LDH/LDH_Scripts/MainGame/MainGameManager/MainGameManager.cs
@@ -262,6 +262,7 @@ namespace LDH_MainGame
                 if (IsMaster)
                 {
                     ForceStopGame();
+                    return;
                 }
             }
             // 2) 마스터 클라이언트이고, 메인 게임 상태가 ready(모든 플레이어의 ready를 기다리고 있는 상태)라면 재조정

--- a/Assets/Resources/Prefabs/UI/Popup/UI_Popup_GameResult.prefab
+++ b/Assets/Resources/Prefabs/UI/Popup/UI_Popup_GameResult.prefab
@@ -53,7 +53,7 @@ MonoBehaviour:
     m_Right: 60
     m_Top: 0
     m_Bottom: 0
-  m_ChildAlignment: 1
+  m_ChildAlignment: 0
   m_Spacing: 90
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 0


### PR DESCRIPTION
# 🧑‍💻 PR

## 🔗 관련 이슈
- 수행한 작업과 관련 작업 번호를 작성해주세요 
<!--
- Resolves: #25 => PR 머지 시 해당 이슈 자동 닫힘
- Related to: #25 => 단순 연결, 자동 닫힘 없음
-->

## 🔥 작업 내용 요약
<!--
1. Feat - 플레이어 이동 구현
2. Fix - 아이템 복사 버그 수정
3. Comment - GameManager 코드 주석 설명 추가
-->
<br>

순위 UI 재수정 및 메인 게임에서 플레이어 이탈시 로직 정지 처리