### PR TITLE
[Fix] Safe Area 외부영역 검은색 렌더링 수정 및 슈팅 게임 설정 버튼 입력 수정

### DIFF
--- a/Assets/AddressableAssetsData/AssetGroups/Unimo.Characters.Packs.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Unimo.Characters.Packs.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
   m_GUID: 23f2ad1c622b042e58717d5a259744d9
   m_SerializeEntries:
   - m_GUID: 04461538a68f1634c8d625592c202503
-    m_Address: Assets/Imports/123/Prefabs/Character/CH009_Al.prefab
+    m_Address: Assets/Imports/UnimoAsset/123/Prefabs/Character/CH009_Al.prefab
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
@@ -29,11 +29,6 @@ MonoBehaviour:
     FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 319efe519960d8f46947e9186ead52bb
     m_Address: Assets/Imports/123/Prefabs/Character/CH013_Toaster.prefab
-    m_ReadOnly: 0
-    m_SerializedLabels: []
-    FlaggedDuringContentUpdateRestriction: 0
-  - m_GUID: 43515d1f3d7fb3b468a6eef5317e9b27
-    m_Address: Assets/Imports/123/Prefabs/Character/CH007_DoomDoom_ST000 (1).prefab
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0

--- a/Assets/LDH/LDH_Scenes/LDH_MainMapScene.unity
+++ b/Assets/LDH/LDH_Scenes/LDH_MainMapScene.unity
@@ -424,7 +424,6 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1613747950}
   - {fileID: 1711905694}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -542,12 +541,12 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1613747949}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 936767708}
+  m_Father: {fileID: 1711905694}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -618,7 +617,7 @@ PrefabInstance:
     - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0.4253049
       objectReference: {fileID: 0}
     - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
         type: 3}
@@ -707,7 +706,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1613747950}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ab169cd4aaf8c4929a6a5e14b129a0b7, type: 3}
 --- !u!224 &1711905694 stripped

--- a/Assets/LTH/LTH_Scripts/Setting/OpenGameSettingPopupButton.cs
+++ b/Assets/LTH/LTH_Scripts/Setting/OpenGameSettingPopupButton.cs
@@ -6,8 +6,9 @@ using ShootingScene;
 using UnityEngine;
 using UnityEngine.UI;
 using PMS_Util;
+using UnityEngine.EventSystems;
 
-public class OpenGameSettingPopupButton : MonoBehaviour
+public class OpenGameSettingPopupButton : MonoBehaviour, IPointerDownHandler
 {
     [SerializeField] private Button button;
 
@@ -17,7 +18,15 @@ public class OpenGameSettingPopupButton : MonoBehaviour
         button.onClick.AddListener(OnClick);
     }
    
-
+    
+    public void OnPointerDown(PointerEventData eventData)
+    {
+        // 게임 입력을 즉시 UI 모드로 전환(터치 다운 프레임 차단)
+        PlayerInputManager.Instance?.ShowPopup();
+    }
+    
+    
+    
     private void OnClick() => OnClickAsync().Forget();
 
     private async UniTask OnClickAsync()
@@ -36,12 +45,15 @@ public class OpenGameSettingPopupButton : MonoBehaviour
             popup = Manager.UI.CreatePopupUI<UI_Popup_GameSetting>();
             if (popup == null) return;
 
-            if (PlayerInputManager.Instance != null)
-            {
-                PlayerInputManager.Instance.ShowPopup();
-                restoreInput = (_) => PlayerInputManager.Instance?.ClosePopup();
-                popup.OnCloseRequested += restoreInput;
-            }
+            //팝업 닫히면 입력 복원
+            popup.OnCloseRequested += _ => PlayerInputManager.Instance?.ClosePopup();
+            
+            // if (PlayerInputManager.Instance != null)
+            // {
+            //     PlayerInputManager.Instance.ShowPopup();
+            //     restoreInput = (_) => PlayerInputManager.Instance?.ClosePopup();
+            //     popup.OnCloseRequested += restoreInput;
+            // }
 
             await Manager.UI.ShowPopupUI(popup);
 
@@ -85,4 +97,6 @@ public class OpenGameSettingPopupButton : MonoBehaviour
 
         if (button) button.interactable = true;*/
     }
+
+   
 }

--- a/Assets/PMS/PMS_Scripts/PlayerInput/PlayerInputManager.cs
+++ b/Assets/PMS/PMS_Scripts/PlayerInput/PlayerInputManager.cs
@@ -9,8 +9,8 @@ using UnityEngine.EventSystems;
 using UnityEngine.UI;
 using PMS_Util;
 using Cysharp.Threading.Tasks;
-using UnityEngine.InputSystem.Controls;    // ← 이 라인 추가
-using static UnityEditor.PlayerSettings;
+using UnityEngine.InputSystem.Controls;
+
 
 
 namespace ShootingScene

--- a/Assets/Scenes/Splash Scene.unity
+++ b/Assets/Scenes/Splash Scene.unity
@@ -503,7 +503,7 @@ Camera:
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 2
-  m_BackGroundColor: {r: 1, g: 1, b: 1, a: 0}
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 1}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0

--- a/Assets/Scenes/Splash Scene.unity
+++ b/Assets/Scenes/Splash Scene.unity
@@ -134,7 +134,6 @@ GameObject:
   - component: {fileID: 256131644}
   - component: {fileID: 256131643}
   - component: {fileID: 256131642}
-  - component: {fileID: 256131646}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -217,8 +216,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1511586780}
-  - {fileID: 1970628854}
+  - {fileID: 295360137}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -226,18 +224,138 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!114 &256131646
-MonoBehaviour:
+--- !u!1001 &295360136
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 256131645}
+    m_Modifications:
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5106584705884229252, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      propertyPath: m_Name
+      value: 00_SafeArea
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1511586780}
+    - targetCorrespondingSourceObject: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1970628854}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ab169cd4aaf8c4929a6a5e14b129a0b7, type: 3}
+--- !u!224 &295360137 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4827618967646636642, guid: ab169cd4aaf8c4929a6a5e14b129a0b7,
+    type: 3}
+  m_PrefabInstance: {fileID: 295360136}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 256131641}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9583950230a132b4d825d4e5643147aa, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &970152634
 GameObject:
   m_ObjectHideFlags: 0
@@ -419,12 +537,12 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1511586779}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 256131645}
+  m_Father: {fileID: 295360137}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -630,12 +748,12 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1970628853}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 256131645}
+  m_Father: {fileID: 295360137}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}


### PR DESCRIPTION
# 🧑‍💻 PR


## 💻 버그 해결방법 (Fix 전용)

### 🔧 수정된 버그
<!--
예) 아이템 호버링, 사운드 누락
-->

- 이전에 SafeArea 외부영역을 검은색으로 렌더링 되도록 수정했음에도 불구하고 하얀색으로 보이는 문제, 메인 맵에서는 배경이 그대로 보이는 문제 수정
- 슈팅 게임에서 자기 차례일때 설정 버튼을 누르면 플레이어 입력이 처리되는 문제 수정

### 💡 해결방법
- splash 화면이 safe area를 적용하지 않아 외부 영역이 splash 배경 색인 하얀색으로 렌더링 되고, 그 이후 다른 씬에서는 카메라가 해당 영역을 렌더링 하지 않게 되면서 하얀색으로 그대로 남아있는 문제가 있었음. splash 화면을 safe area 영역 내로 옮기고 외부 영역을 검은색으로 렌더링 되도록 씬 수정
- 설정 버튼을 눌렀을 때 로직이 onclick에 연동되어 있는데, 플레이어 입력은 touch press 즉, 눌렀을 때 반응하기 때문에 player 입력이 먼저 처리되어버림. OpenGameSettingPopupButton에 IPointerDownHandler를 추가하여 InputManager의 경우 아래와 같이 포인터 다운일 때 처리로 변경

```csharp
    public void OnPointerDown(PointerEventData eventData)
    {
        // 게임 입력을 즉시 UI 모드로 전환(터치 다운 프레임 차단)
        PlayerInputManager.Instance?.ShowPopup();
    }
    
```

### ✔️ 버그 체크리스트
- [ ] 추가로 수정이 필요함
- [x] 수정 완료
- [ ] QA 테스트 통과

## ✅ PR 체크리스트
- [ ] 빌드 오류 없음
- [x] 기능 정상 작동 확인
- [x] 커밋 메시지 규칙 준수
- [x] Scene 충돌 없음

## 💬 기타 사항
- 리뷰어에게 공유하고 싶은 내용